### PR TITLE
Put back permission security-events: write to permit codeql to run

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -22,6 +22,7 @@ concurrency:
 permissions:
   contents: read
   checks: read  # Required by reusable-test.yml to check build status.
+  security-events: write # Required by codeql task
 
 jobs:
   # Perform the regular build.

--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -22,6 +22,7 @@ on:
 
 permissions:
   contents: read
+  security-events: write # Required by codeql task
 
 jobs:
   build:


### PR DESCRIPTION
Signed-off-by: Alan Jowett <alanjo@microsoft.com>

## Description

github/codeql-action/init requires ```security-events: write```.

## Testing

CI/CD

## Documentation

N/A
