### PR TITLE
Integrate netperf

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -578,6 +578,16 @@ jobs:
       environment: ebpf_cicd_perf_ws2022
       configurations: '["Release"]'
 
+  netperf:
+    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+    uses: ./.github/workflows/netperf.yml
+    with:
+      sha: ${{ github.sha }}
+      ref: ${{ github.ref }}
+      pull_request: ${{ github.event.pull_request.number }}
+    secrets:
+      NET_PERF_TRIGGER: ${{ secrets.NET_PERF_TRIGGER }}
+
   upload_perf_results:
     needs: performance
     if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
@@ -585,6 +595,45 @@ jobs:
     with:
       name: upload_perf_results
       result_artifact: km_performance-x64-Release
+    secrets:
+      AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
+      AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
+      AZURE_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+
+  upload_netperf_results_azure_2022:
+    needs: netperf
+    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+    uses: ./.github/workflows/upload-perf-results.yml
+    with:
+      name: upload_netperf_results_azure_2022
+      result_artifact: bpf_performance_native_azure_2022_x64
+      platform: Azure Windows 2022
+    secrets:
+      AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
+      AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
+      AZURE_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+
+  upload_netperf_results_azure_2025:
+    needs: netperf
+    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+    uses: ./.github/workflows/upload-perf-results.yml
+    with:
+      name: upload_netperf_results_azure_2025
+      result_artifact: bpf_performance_native_azure_2025_x64
+      platform: Azure Windows 2025
+    secrets:
+      AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
+      AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
+      AZURE_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+
+  upload_netperf_results_lab_2022:
+    needs: netperf
+    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+    uses: ./.github/workflows/upload-perf-results.yml
+    with:
+      name: upload_netperf_results_lab_2022
+      result_artifact: bpf_performance_native_lab_2022_x64
+      platform: Lab Windows 2022
     secrets:
       AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
       AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}

--- a/.github/workflows/netperf.yml
+++ b/.github/workflows/netperf.yml
@@ -1,0 +1,66 @@
+# Copyright (c) Microsoft Corporation
+# SPDX-License-Identifier: MIT
+
+# This is a workflow which runs the performance tests with profiling enabled.
+
+name: Performance Tests on netperf
+
+on:
+  # Permit manual runs of the workflow.
+  workflow_call:
+    inputs:
+      sha:
+        description: 'SHA of the commit'
+        required: true
+        type: string
+      ref:
+        description: 'Ref of the commit'
+        required: true
+        type: string
+      pull_request:
+        description: 'Pull request number'
+        required: true
+        type: string
+    secrets:
+      NET_PERF_TRIGGER:
+        description: 'Token to trigger the NetPerf workflow'
+        required: true
+
+permissions:
+  contents: read
+
+jobs:
+    netperf:
+      runs-on: windows-latest
+      steps:
+      - name: Run NetPerf Workflow
+        shell: pwsh
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          $url = "https://raw.githubusercontent.com/microsoft/netperf/main/run-workflow.ps1"
+          if ('${{ secrets.NET_PERF_TRIGGER }}' -eq '') {
+              Write-Host "Not able to run because no secrets are available!"
+              return
+          }
+          $run_id = iex "& { $(irm $url) } ${{ secrets.NET_PERF_TRIGGER }} ebpf ${{ inputs.sha }} ${{ inputs.ref }} ${{ inputs.pull_request.number }}"
+          echo "NetPerf run id: $run_id"
+          gh run download $run_id --dir netperf --pattern bpf_performance_native* --repo microsoft/netperf
+
+      - name: upload_results_azure_2022_x64
+        uses: actions/upload-artifact@5d5d22a31266ced268874388b861e4b58bb5c2f3
+        with:
+            name: Test-Logs-bpf_performance_native_azure_2022_x64
+            path: netperf/bpf_performance_native_azure_2022_x64/bpf_performance_native.csv
+
+      - name: upload_results_azure_2025_x64
+        uses: actions/upload-artifact@5d5d22a31266ced268874388b861e4b58bb5c2f3
+        with:
+            name: Test-Logs-bpf_performance_native_azure_2025_x64
+            path: netperf/bpf_performance_native_azure_2025_x64/bpf_performance_native.csv
+
+      - name: upload_results_lab_2022_x64
+        uses: actions/upload-artifact@5d5d22a31266ced268874388b861e4b58bb5c2f3
+        with:
+            name: Test-Logs-bpf_performance_native_lab_2022_x64
+            path: netperf/bpf_performance_native_lab_2022_x64/bpf_performance_native.csv

--- a/.github/workflows/upload-perf-results.yml
+++ b/.github/workflows/upload-perf-results.yml
@@ -14,6 +14,10 @@ on:
       result_artifact:
         required: true
         type: string
+      platform:
+        required: false
+        type: string
+        default: "Windows 2019"
     secrets:
       AZURE_CLIENT_ID:
         required: true
@@ -57,7 +61,7 @@ jobs:
         # Compare hash of downloaded script.
         sha256sum process_results.py | grep dc616f27b6d345e8086de451ffd3f73cc71b5d51d18894ce08c02db56d67e0f4 -q || exit 1
         # Run script to convert CSV to SQL.
-        python3 ./process_results.py --csv-directory ${{github.workspace}}/results/${{github.sha}} --sql-script-file ${{github.workspace}}/results/upload.sql --commit_id ${{github.sha}} --platform "Windows 2019" --repository ${{github.repository}}
+        python3 ./process_results.py --csv-directory ${{github.workspace}}/results/${{github.sha}} --sql-script-file ${{github.workspace}}/results/upload.sql --commit_id ${{github.sha}} --platform "${{inputs.platform}}" --repository ${{github.repository}}
 
     # Grab the output from the results directory and upload it as an artifact to debug failures.
     - name: Upload data as artifacts for debugging


### PR DESCRIPTION
## Description

The "skip-duplicate-actions" check breaks reusuable-build.yml when called from another workflow.

## Testing

_Do any existing tests cover this change? Are new tests needed?_

## Documentation

_Is there any documentation impact for this change?_

## Installation

_Is there any installer impact for this change?_
