### PR TITLE
Add backup watchdog timer

### DIFF
--- a/scripts/Run-Self-Hosted-Runner-Test.ps1
+++ b/scripts/Run-Self-Hosted-Runner-Test.ps1
@@ -74,6 +74,34 @@ function GetDriveFreeSpaceGB
     return $FreeSpaceGB
 }
 
+$timer = $null
+
+function StartWatchDogTimer
+{
+    param(
+        [Parameter(Mandatory = $true)] [string] $ActionOnTimeout,
+        [Parameter(Mandatory = $false)] [int] $Timeout = 3600
+    )
+    $timer = New-Object System.Timers.Timer
+    $timer.Interval = $Timeout * 1000 # Convert seconds to milliseconds.
+    $timer.AutoReset = $false
+
+    $timer.add_Elapsed({
+        Write-Log "Watchdog timer expired. Killing the test process."
+        & $ActionOnTimeout
+    })
+
+    $timer.Start()
+}
+
+function StopWatchDogTimer
+{
+    if ($timer -ne $null) {
+        $timer.Stop()
+        $timer.Dispose()
+    }
+}
+
 if ($VerbosePreference -eq 'Continue') {
     Write-Log "Command               : $TestCommand"
     Write-Log "Arguments             : $TestArguments"
@@ -138,6 +166,8 @@ if ($VerbosePreference -eq 'Continue') {
     }
     Write-Log "`n"
 }
+
+StartWatchDogTimer -ActionOnTimeout "$NotMyFaultBinaryPath /crash" -Timeout ($TestHangTimeout * 1.1)
 
 # Get the available free space before test start (useful in investigating dump file creation failures)
 try {
@@ -279,3 +309,5 @@ if (-not $WaitResult) {
         ThrowWithErrorMessage -ErrorMessage $ErrorMessage
     }
 }
+
+StopWatchDogTimer


### PR DESCRIPTION
## Description

This pull request to `scripts/Run-Self-Hosted-Runner-Test.ps1` introduces a watchdog timer to monitor and handle test hangs. The key changes include adding functions to start and stop the timer and integrating these functions into the script's workflow.

### Watchdog Timer Implementation:

* [`scripts/Run-Self-Hosted-Runner-Test.ps1`](diffhunk://#diff-6f04ed49d71e76ed280622ae1637aad0696fad978c1550074babe2236e4929cbR77-R104): Added `StartWatchDogTimer` function to initialize and start a timer that executes a specified action on timeout.
* [`scripts/Run-Self-Hosted-Runner-Test.ps1`](diffhunk://#diff-6f04ed49d71e76ed280622ae1637aad0696fad978c1550074babe2236e4929cbR77-R104): Added `StopWatchDogTimer` function to stop and dispose of the timer.

### Integration into Test Workflow:

* [`scripts/Run-Self-Hosted-Runner-Test.ps1`](diffhunk://#diff-6f04ed49d71e76ed280622ae1637aad0696fad978c1550074babe2236e4929cbR170-R171): Integrated `StartWatchDogTimer` at the beginning of the test execution to trigger a crash action if the test hangs.
* [`scripts/Run-Self-Hosted-Runner-Test.ps1`](diffhunk://#diff-6f04ed49d71e76ed280622ae1637aad0696fad978c1550074babe2236e4929cbR312-R313): Integrated `StopWatchDogTimer` after the test execution to ensure the timer is stopped and disposed of properly.

## Testing

CI/CD

## Documentation

No.

## Installation

No.
