### PR TITLE
Switch to group affinity

### DIFF
--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -25,6 +25,6 @@ jobs:
           egress-policy: audit
 
       - name: 'Checkout Repository'
-        uses: actions/checkout@d632683dd7b4114ad314bca15554477dd762a938 # v4.2.0
+        uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
       - name: 'Dependency Review'
         uses: actions/dependency-review-action@5a2ce3f5b92ee19cbb1541a4984c76d921601d7c # v4.3.4

--- a/.github/workflows/netperf.yml
+++ b/.github/workflows/netperf.yml
@@ -53,13 +53,13 @@ jobs:
           gh run download $run_id --dir netperf --pattern ebpf* --repo microsoft/netperf
 
       - name: upload_results_azure_2022_x64
-        uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874
+        uses: actions/upload-artifact@604373da6381bf24206979c74d06a550515601b9
         with:
             name: Test-Logs-netperf_azure_2022_x64
             path: netperf/ebpf_azure_2022_x64/ebpf.csv
 
       - name: upload_results_lab_2022_x64
-        uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874
+        uses: actions/upload-artifact@604373da6381bf24206979c74d06a550515601b9
         with:
             name: Test-Logs-netperf_lab_2022_x64
             path: netperf/ebpf_lab_2022_x64/ebpf.csv

--- a/.github/workflows/nuget_update.yaml
+++ b/.github/workflows/nuget_update.yaml
@@ -37,14 +37,14 @@ jobs:
       with:
         egress-policy: audit
 
-    - uses: actions/checkout@d632683dd7b4114ad314bca15554477dd762a938
+    - uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871
       with:
         # Only check out main repo, not submodules.
         ref: ${{ github.event.workflow_run.head_branch }}
 
 
     - name: Cache nuget packages
-      uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9
+      uses: actions/cache@2cdf405574d6ef1f33a1d12acccd3ae82f47b3f2
       env:
         cache-name: cache-nuget-modules
       with:

--- a/.github/workflows/ossar-scan.yml
+++ b/.github/workflows/ossar-scan.yml
@@ -47,7 +47,7 @@ jobs:
         paths_ignore: '["**.md", "**/docs/**"]'
 
     # Checking out the branch is needed to correctly log security alerts.
-    - uses: actions/checkout@d632683dd7b4114ad314bca15554477dd762a938
+    - uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871
       if: steps.skip_check.outputs.should_skip != 'true'
       with:
         # Only check out main repo, not submodules.
@@ -81,6 +81,6 @@ jobs:
 
     - name: Upload results to Security tab
       if: steps.skip_check.outputs.should_skip != 'true'
-      uses: github/codeql-action/upload-sarif@461ef6c76dfe95d5c364de2f431ddbd31a417628
+      uses: github/codeql-action/upload-sarif@c36620d31ac7c881962c3d9dd939c40ec9434f2b
       with:
         sarif_file: ${{ steps.ossar.outputs.sarifFile }}

--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -109,7 +109,7 @@ jobs:
         powershell.exe "echo 'ASAN_WIN_CONTINUE_ON_INTERCEPTION_FAILURE=true' | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append"
         powershell.exe "echo 'VCINSTALLDIR=%VCINSTALLDIR%' | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append"
 
-    - uses: actions/checkout@d632683dd7b4114ad314bca15554477dd762a938
+    - uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871
       if: steps.skip_check.outputs.should_skip != 'true'
       with:
         repository: ${{inputs.repository}}
@@ -127,7 +127,7 @@ jobs:
 
     - name: Initialize CodeQL
       if: inputs.build_codeql == true && steps.skip_check.outputs.should_skip != 'true'
-      uses: github/codeql-action/init@461ef6c76dfe95d5c364de2f431ddbd31a417628
+      uses: github/codeql-action/init@c36620d31ac7c881962c3d9dd939c40ec9434f2b
       with:
         languages: 'cpp'
 
@@ -146,7 +146,7 @@ jobs:
 
     - name: Cache nuget packages
       if: steps.skip_check.outputs.should_skip != 'true'
-      uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9
+      uses: actions/cache@2cdf405574d6ef1f33a1d12acccd3ae82f47b3f2
       env:
         cache-name: cache-nuget-modules
       with:
@@ -156,7 +156,7 @@ jobs:
     - name: Cache verifier project
       # The hash is based on the HEAD of the ebpf-verifier submodule, the Directory.Build.props file, and the build variant.
       if: steps.skip_check.outputs.should_skip != 'true'
-      uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9
+      uses: actions/cache@2cdf405574d6ef1f33a1d12acccd3ae82f47b3f2
       env:
         cache-name: cache-verifier-project
       with:
@@ -229,7 +229,7 @@ jobs:
 
     - name: Upload Build Output
       if: always() && (steps.skip_check.outputs.should_skip != 'true') && (inputs.build_artifact != 'none')
-      uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874
+      uses: actions/upload-artifact@604373da6381bf24206979c74d06a550515601b9
       with:
         name: ${{inputs.build_artifact}}-${{matrix.configurations}}
         path: ${{github.workspace}}/build-${{ matrix.configurations }}.zip
@@ -237,7 +237,7 @@ jobs:
 
     - name: Upload the MSI package
       if: inputs.build_msi == true
-      uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874
+      uses: actions/upload-artifact@604373da6381bf24206979c74d06a550515601b9
       with:
         name: ebpf-for-windows - MSI installer (${{inputs.build_artifact}}_${{env.BUILD_CONFIGURATION}})
         path: ${{github.workspace}}/${{env.BUILD_PLATFORM}}/${{env.BUILD_CONFIGURATION}}/ebpf-for-windows.msi
@@ -249,7 +249,7 @@ jobs:
 
     - name: Upload the NuGet package
       if: inputs.build_nuget == true && matrix.configurations == 'Release' && steps.skip_check.outputs.should_skip != 'true'
-      uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874
+      uses: actions/upload-artifact@604373da6381bf24206979c74d06a550515601b9
       with:
         name: ebpf-for-windows - NuGet package (${{inputs.build_artifact}}_${{env.BUILD_CONFIGURATION}})
         path: ${{github.workspace}}/${{env.BUILD_PLATFORM}}/${{env.BUILD_CONFIGURATION}}/eBPF-for-Windows.*.nupkg
@@ -261,7 +261,7 @@ jobs:
 
     - name: Upload the NuGet Redist package
       if: inputs.build_nuget == true && (matrix.configurations == 'Release' || matrix.configurations == 'NativeOnlyRelease') && steps.skip_check.outputs.should_skip != 'true'
-      uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874
+      uses: actions/upload-artifact@604373da6381bf24206979c74d06a550515601b9
       with:
         name: ebpf-for-windows - NuGet Redist package (${{inputs.build_artifact}}_${{env.BUILD_CONFIGURATION}})
         path: ${{github.workspace}}/${{env.BUILD_PLATFORM}}/${{env.BUILD_CONFIGURATION}}/eBPF-for-Windows-Redist.*.nupkg
@@ -277,7 +277,7 @@ jobs:
     - name: Upload any crash dumps
       # Upload crash dumps even if the workflow failed.
       if: (success() || failure()) && (steps.skip_check.outputs.should_skip != 'true') && (steps.check_dumps.outputs.files_exists == 'true')
-      uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874
+      uses: actions/upload-artifact@604373da6381bf24206979c74d06a550515601b9
       id: upload_crash_dumps
       with:
         name: Crash-Dumps-${{env.NAME}}-${{env.BUILD_PLATFORM}}-${{env.BUILD_CONFIGURATION}}
@@ -286,4 +286,4 @@ jobs:
 
     - name: Perform CodeQL Analysis
       if: inputs.build_codeql == true && steps.skip_check.outputs.should_skip != 'true'
-      uses: github/codeql-action/analyze@461ef6c76dfe95d5c364de2f431ddbd31a417628
+      uses: github/codeql-action/analyze@c36620d31ac7c881962c3d9dd939c40ec9434f2b

--- a/.github/workflows/reusable-test.yml
+++ b/.github/workflows/reusable-test.yml
@@ -100,7 +100,7 @@ jobs:
         paths_ignore: '["**.md", "**/docs/**"]'
 
     # Checking out the branch is needed to gather correct code coverage data.
-    - uses: actions/checkout@d632683dd7b4114ad314bca15554477dd762a938
+    - uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871
       # Only check out source code if code coverage is being gathered.
       if: (inputs.code_coverage == true) && (steps.skip_check.outputs.should_skip != 'true')
       with:
@@ -108,7 +108,7 @@ jobs:
         ref: ${{ github.event.workflow_run.head_branch }}
 
     # Perform shallow checkout for self-hosted runner.
-    - uses: actions/checkout@d632683dd7b4114ad314bca15554477dd762a938
+    - uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871
       if: (inputs.environment == 'ebpf_cicd_tests_ws2019' || inputs.environment == 'ebpf_cicd_tests_ws2022' || inputs.environment == 'ebpf_cicd_perf_ws2022') && (steps.skip_check.outputs.should_skip != 'true')
       with:
         ref: ${{ github.event.workflow_run.head_branch }}
@@ -123,7 +123,7 @@ jobs:
         files: .github/workflows/reusable-test.yml
 
     # Check out just this file if code hasn't been checked out yet.
-    - uses: actions/checkout@d632683dd7b4114ad314bca15554477dd762a938
+    - uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871
       if: (steps.check_reusable_test_locally.outputs.files_exists != 'true') && (steps.skip_check.outputs.should_skip != 'true')
       with:
         sparse-checkout: |
@@ -142,7 +142,7 @@ jobs:
       # Add cache entry for any choco packages that are installed.
       # The cache key is based on the hash of this file so if any choco packages are added or removed, the cache will be invalidated.
       if: (inputs.gather_dumps == true) && (steps.skip_check.outputs.should_skip != 'true')
-      uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9
+      uses: actions/cache@2cdf405574d6ef1f33a1d12acccd3ae82f47b3f2
       env:
         cache-name: cache-choco-packages
       with:
@@ -321,7 +321,7 @@ jobs:
 
     - name: Upload Report to Codecov attempt 1
       if: (steps.skip_check.outputs.should_skip != 'true') && (steps.check_coverage.outputs.files_exists == 'true')
-      uses: codecov/codecov-action@e28ff129e5465c2c0dcc6f003fc735cb6ae0c673
+      uses: codecov/codecov-action@b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238
       id: upload_code_coverage_report_1
       continue-on-error: true
       with:
@@ -336,7 +336,7 @@ jobs:
 
     - name: Upload Report to Codecov attempt 2
       if: (steps.skip_check.outputs.should_skip != 'true') && (steps.upload_code_coverage_report_1.outcome == 'failure')
-      uses: codecov/codecov-action@e28ff129e5465c2c0dcc6f003fc735cb6ae0c673
+      uses: codecov/codecov-action@b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238
       id: upload_code_coverage_report_2
       continue-on-error: true
       with:
@@ -351,7 +351,7 @@ jobs:
 
     - name: Upload Report to Codecov attempt 3
       if: (steps.skip_check.outputs.should_skip != 'true') && (steps.upload_code_coverage_report_2.outcome == 'failure')
-      uses: codecov/codecov-action@e28ff129e5465c2c0dcc6f003fc735cb6ae0c673
+      uses: codecov/codecov-action@b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238
       id: upload_code_coverage_report_3
       continue-on-error: true
       with:
@@ -366,7 +366,7 @@ jobs:
 
     - name: Upload Report to Codecov attempt 4
       if: (steps.skip_check.outputs.should_skip != 'true') && (steps.upload_code_coverage_report_3.outcome == 'failure')
-      uses: codecov/codecov-action@e28ff129e5465c2c0dcc6f003fc735cb6ae0c673
+      uses: codecov/codecov-action@b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238
       id: upload_code_coverage_report_4
       continue-on-error: true
       with:
@@ -408,7 +408,7 @@ jobs:
     - name: Upload any crash dumps
       # Upload crash dumps even if the workflow failed.
       if: always() && (steps.skip_check.outputs.should_skip != 'true') && (steps.check_dumps.outputs.files_exists == 'true') && (inputs.gather_dumps == true)
-      uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874
+      uses: actions/upload-artifact@604373da6381bf24206979c74d06a550515601b9
       id: upload_crash_dumps
       with:
         name: Crash-Dumps-${{env.NAME}}-${{env.BUILD_PLATFORM}}-${{env.BUILD_CONFIGURATION}}
@@ -427,7 +427,7 @@ jobs:
       # Upload test logs even if the workflow failed.
       if: (success() || failure()) && (steps.skip_check.outputs.should_skip != 'true') && (steps.check_logs.outputs.files_exists == 'true')
       id: upload_logs
-      uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874
+      uses: actions/upload-artifact@604373da6381bf24206979c74d06a550515601b9
       continue-on-error: true
       with:
         name: Test-Logs-${{env.NAME}}-${{env.BUILD_PLATFORM}}-${{env.BUILD_CONFIGURATION}}
@@ -447,7 +447,7 @@ jobs:
       if: (success() || failure()) && (steps.skip_check.outputs.should_skip != 'true') && (steps.check_artifacts.outputs.files_exists == 'true')
       id: upload_artifacts
       continue-on-error: true
-      uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874
+      uses: actions/upload-artifact@604373da6381bf24206979c74d06a550515601b9
       with:
         name: Artifacts-${{env.NAME}}-${{env.BUILD_PLATFORM}}-${{env.BUILD_CONFIGURATION}}
         path: ${{github.workspace}}\${{env.BUILD_PLATFORM}}\${{env.BUILD_CONFIGURATION}}\Artifacts

--- a/.github/workflows/scorecards-analysis.yml
+++ b/.github/workflows/scorecards-analysis.yml
@@ -45,7 +45,7 @@ jobs:
 
       - name: "Checkout code"
         if: github.ref_name == 'main'
-        uses: actions/checkout@d632683dd7b4114ad314bca15554477dd762a938
+        uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871
         with:
           persist-credentials: false
 
@@ -67,7 +67,7 @@ jobs:
       # Upload the results as artifacts (optional).
       - name: "Upload artifact"
         if: github.ref_name == 'main'
-        uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874
+        uses: actions/upload-artifact@604373da6381bf24206979c74d06a550515601b9
         with:
           name: SARIF file
           path: results.sarif
@@ -76,6 +76,6 @@ jobs:
       # Upload the results to GitHub's code scanning dashboard.
       - name: "Upload to code-scanning"
         if: github.ref_name == 'main'
-        uses: github/codeql-action/upload-sarif@461ef6c76dfe95d5c364de2f431ddbd31a417628
+        uses: github/codeql-action/upload-sarif@c36620d31ac7c881962c3d9dd939c40ec9434f2b
         with:
           sarif_file: results.sarif

--- a/.github/workflows/update-docs.yml
+++ b/.github/workflows/update-docs.yml
@@ -41,7 +41,7 @@ jobs:
       run: |
         sudo apt install doxygen
 
-    - uses: actions/checkout@d632683dd7b4114ad314bca15554477dd762a938
+    - uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871
 
     - name: Clone docs
       run: |

--- a/.github/workflows/upload-perf-results.yml
+++ b/.github/workflows/upload-perf-results.yml
@@ -65,7 +65,7 @@ jobs:
 
     # Grab the output from the results directory and upload it as an artifact to debug failures.
     - name: Upload data as artifacts for debugging
-      uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874
+      uses: actions/upload-artifact@604373da6381bf24206979c74d06a550515601b9
       with:
         name: Test-Results-${{inputs.result_artifact}}
         path: ${{github.workspace}}/results

--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -57,7 +57,7 @@ Alternative install steps (for *basic* Visual Studio Community edition):
 
    ```ps
    Invoke-WebRequest 'https://raw.githubusercontent.com/microsoft/ebpf-for-windows/main/scripts/Setup-DevEnv.ps1' -OutFile $env:TEMP\Setup-DeveEnv.ps1
-   if ((get-filehash -Algorithm SHA256 $env:TEMP\Setup-DeveEnv.ps1).Hash -eq '0E8733AC82CFDEC93A3606AEA586A6BD08980D2301754EC165230FBA353E7B4C') { &"$env:TEMP\Setup-DeveEnv.ps1" }
+   if ((get-filehash -Algorithm SHA256 $env:TEMP\Setup-DeveEnv.ps1).Hash -eq '36C16D8455E8867E64EFA1D1AF5223CEF9CDB4394C3B76B6AA09B46F3F26E7A8') { &"$env:TEMP\Setup-DeveEnv.ps1" }
    ```
 
    >**Note**: the WDK for Windows 11 is [not currently available on Chocolatey](https://community.chocolatey.org/packages?q=windowsdriverkit),

--- a/libs/api/libbpf_object.cpp
+++ b/libs/api/libbpf_object.cpp
@@ -83,8 +83,8 @@ int
 bpf_obj_get(const char* pathname)
 {
     fd_t fd = -1;
-    libbpf_result_err(ebpf_object_get(pathname, &fd)); // set the errno
-    return fd;
+    int result = libbpf_result_err(ebpf_object_get(pathname, &fd));
+    return result ? result : fd;
 }
 
 struct bpf_object*

--- a/libs/execution_context/ebpf_maps.c
+++ b/libs/execution_context/ebpf_maps.c
@@ -476,7 +476,7 @@ _find_array_map_entry(
     key_value = *(uint32_t*)key;
 
     if (key_value >= map->ebpf_map_definition.max_entries) {
-        return EBPF_INVALID_ARGUMENT;
+        return EBPF_OBJECT_NOT_FOUND;
     }
 
     *data = &map->data[key_value * map->ebpf_map_definition.value_size];

--- a/libs/execution_context/ebpf_program.c
+++ b/libs/execution_context/ebpf_program.c
@@ -2389,7 +2389,7 @@ _ebpf_program_test_run_work_item(_In_ cxplat_preemptible_work_item_t* work_item,
     ebpf_result_t result;
     uint32_t return_value = 0;
     uint8_t old_irql = 0;
-    uintptr_t old_thread_affinity;
+    GROUP_AFFINITY old_thread_affinity;
     size_t batch_size = options->batch_size ? options->batch_size : 1024;
     ebpf_execution_context_state_t execution_context_state = {0};
     ebpf_epoch_state_t epoch_state = {0};
@@ -2400,7 +2400,7 @@ _ebpf_program_test_run_work_item(_In_ cxplat_preemptible_work_item_t* work_item,
     void* program_context = NULL;
     bool supports_context_header;
 
-    result = ebpf_set_current_thread_affinity((uintptr_t)1 << options->cpu, &old_thread_affinity);
+    result = ebpf_set_current_thread_cpu_affinity(options->cpu, &old_thread_affinity);
     if (result != EBPF_SUCCESS) {
         goto Done;
     }
@@ -2501,7 +2501,7 @@ Done:
     }
 
     if (thread_affinity_set) {
-        ebpf_restore_current_thread_affinity(old_thread_affinity);
+        ebpf_restore_current_thread_cpu_affinity(&old_thread_affinity);
     }
 
     context->completion_callback(

--- a/libs/runtime/ebpf_epoch.c
+++ b/libs/runtime/ebpf_epoch.c
@@ -17,23 +17,7 @@
  * 1) Each CPU determines the minimum epoch of all threads on the CPU.
  * 2) The minimum epoch is committed as the release epoch and any memory that is older than the release epoch is
  * released.
- * 3) The epoch_computation_in_progress flag is cleared which allows the epoch computation to be initiated again.
- *
- * Note:
- * CPUs can be in one of three states:
- * 1) Inactive: The CPU is not actively participating in epoch computation.
- *  Active flag is false.
- * 2) Activating: The CPU is in the process of activating and is not yet active.
- *  Active flag is true and current_epoch == EBPF_EPOCH_UNKNOWN_EPOCH.
- * 3) Active: The CPU is actively participating in epoch computation.
- *  Active flag is true and current_epoch != EBPF_EPOCH_UNKNOWN_EPOCH.
- *
- * All CPUs except CPU 0 are in the inactive state at initialization. CPU 0 is always active.
- *
- * CPUs transition between states as follows:
- * 1) Inactive -> Activating: The CPU is activated when a thread enters an epoch and the CPU is not active.
- * 2) Activating -> Active: The CPU is active when it is notified of the current epoch value.
- * 3) Active -> Inactive: The CPU is deactivated when there are no threads in the epoch and the free list is empty.
+ * 3) The epoch_computation_in_progress flag is cleared which allows the epoch computation to be initiated  again.
  */
 
 /**
@@ -46,19 +30,9 @@
  */
 #define EBPF_NANO_SECONDS_PER_FILETIME_TICK 100
 
-/**
- * @brief A sentinel value used to indicate that the epoch is unknown.
- */
-#define EBPF_EPOCH_UNKNOWN_EPOCH 0
-
-/**
- * @brief The first valid epoch value.
- */
-#define EBPF_EPOCH_FIRST_EPOCH 1
-
 #define EBPF_EPOCH_FAIL_FAST(REASON, ASSERTION) \
     if (!(ASSERTION)) {                         \
-        ebpf_assert(#ASSERTION);                \
+        ebpf_assert(!#ASSERTION);               \
         __fastfail(REASON);                     \
     }
 
@@ -77,18 +51,8 @@ typedef __declspec(align(EBPF_CACHE_LINE_SIZE)) struct _ebpf_epoch_cpu_entry
     int timer_armed : 1;                   ///< Set if the flush timer is armed.
     int rundown_in_progress : 1;           ///< Set if rundown is in progress.
     int epoch_computation_in_progress : 1; ///< Set if epoch computation is in progress.
-    int active : 1; ///< CPU is active in epoch computation. Only accessed under _ebpf_epoch_cpu_active_lock.
-    int work_queue_assigned : 1;         ///< Work queue is assigned to this CPU.
-    ebpf_timed_work_queue_t* work_queue; ///< Work queue used to schedule work items.
+    ebpf_timed_work_queue_t* work_queue;   ///< Work queue used to schedule work items.
 } ebpf_epoch_cpu_entry_t;
-
-static_assert(
-    sizeof(ebpf_epoch_cpu_entry_t) % EBPF_CACHE_LINE_SIZE == 0, "ebpf_epoch_cpu_entry_t is not cache aligned");
-
-/**
- * @brief Lock to ensure a consistent view of the active CPUs.
- */
-static ebpf_lock_t _ebpf_epoch_cpu_active_lock; ///< Lock to protect the active CPU list.
 
 /**
  * @brief Table of per-CPU state.
@@ -152,12 +116,12 @@ typedef struct _ebpf_epoch_cpu_message
     {
         struct
         {
-            int64_t current_epoch;          ///< The new current epoch.
-            int64_t proposed_release_epoch; ///< Minimum epoch of all threads on the CPU.
+            uint64_t current_epoch;          ///< The new current epoch.
+            uint64_t proposed_release_epoch; ///< Minimum epoch of all threads on the CPU.
         } propose_epoch;
         struct
         {
-            int64_t released_epoch; ///< The newest epoch that can be released.
+            uint64_t released_epoch; ///< The newest epoch that can be released.
         } commit_epoch;
         struct
         {
@@ -260,13 +224,6 @@ static _IRQL_requires_(DISPATCH_LEVEL) void _ebpf_epoch_arm_timer_if_needed(ebpf
 static void
 _ebpf_epoch_work_item_callback(_In_ cxplat_preemptible_work_item_t* preemptible_work_item, void* context);
 
-_IRQL_requires_(DISPATCH_LEVEL) static void _ebpf_epoch_activate_cpu(uint32_t cpu_id);
-
-_IRQL_requires_(DISPATCH_LEVEL) static void _ebpf_epoch_deactivate_cpu(uint32_t cpu_id);
-
-uint32_t
-_ebpf_epoch_next_active_cpu(uint32_t cpu_id);
-
 /**
  * @brief Raise the CPU's IRQL to DISPATCH_LEVEL if it is below DISPATCH_LEVEL.
  * First check if the IRQL is below DISPATCH_LEVEL to avoid the overhead of
@@ -321,13 +278,12 @@ ebpf_epoch_initiate()
         goto Error;
     }
 
-    ebpf_lock_create(&_ebpf_epoch_cpu_active_lock);
-
     ebpf_assert(EBPF_CACHE_ALIGN_POINTER(_ebpf_epoch_cpu_table) == _ebpf_epoch_cpu_table);
 
     // Initialize the per-CPU state.
     for (uint32_t cpu_id = 0; cpu_id < _ebpf_epoch_cpu_count; cpu_id++) {
         ebpf_epoch_cpu_entry_t* cpu_entry = &_ebpf_epoch_cpu_table[cpu_id];
+        cpu_entry->current_epoch = 1;
         ebpf_list_initialize(&cpu_entry->epoch_state_list);
         ebpf_list_initialize(&cpu_entry->free_list);
     }
@@ -345,20 +301,6 @@ ebpf_epoch_initiate()
             goto Error;
         }
     }
-
-    // Set the initial state for CPU 0.
-    // This code can't use _ebpf_epoch_activate_cpu as it may not running on CPU 0.
-    _ebpf_epoch_cpu_table[0].active = true;
-    ebpf_result_t result = ebpf_timed_work_queue_set_cpu_id(_ebpf_epoch_cpu_table[0].work_queue, 0);
-    if (result != EBPF_SUCCESS) {
-        return_value = result;
-        goto Error;
-    }
-
-    _ebpf_epoch_cpu_table[0].work_queue_assigned = 1;
-
-    // Set the current epoch for CPU 0.
-    _ebpf_epoch_cpu_table[0].current_epoch = EBPF_EPOCH_FIRST_EPOCH;
 
     KeInitializeDpc(&_ebpf_epoch_timer_dpc, _ebpf_epoch_timer_worker, NULL);
     KeSetTargetProcessorDpc(&_ebpf_epoch_timer_dpc, 0);
@@ -416,7 +358,6 @@ ebpf_epoch_terminate()
     cxplat_free(
         _ebpf_epoch_cpu_table, CXPLAT_POOL_FLAG_NON_PAGED | CXPLAT_POOL_FLAG_CACHE_ALIGNED, EBPF_POOL_TAG_EPOCH);
     _ebpf_epoch_cpu_table = NULL;
-
     EBPF_RETURN_VOID();
 }
 
@@ -433,10 +374,6 @@ ebpf_epoch_enter(_Out_ ebpf_epoch_state_t* epoch_state)
     ebpf_epoch_cpu_entry_t* cpu_entry = &_ebpf_epoch_cpu_table[epoch_state->cpu_id];
     epoch_state->epoch = cpu_entry->current_epoch;
     ebpf_list_insert_tail(&cpu_entry->epoch_state_list, &epoch_state->epoch_list_entry);
-
-    if (!cpu_entry->active) {
-        _ebpf_epoch_activate_cpu(epoch_state->cpu_id);
-    }
 
     _ebpf_epoch_lower_to_previous_irql(epoch_state->irql_at_enter);
 }
@@ -713,10 +650,6 @@ _ebpf_epoch_insert_in_free_list(_In_ ebpf_epoch_allocation_header_t* header)
     uint32_t cpu_id = ebpf_get_current_cpu();
     ebpf_epoch_cpu_entry_t* cpu_entry = &_ebpf_epoch_cpu_table[cpu_id];
 
-    if (!cpu_entry->active) {
-        _ebpf_epoch_activate_cpu(cpu_id);
-    }
-
     if (cpu_entry->rundown_in_progress) {
         KeLowerIrql(old_irql);
         switch (header->entry_type) {
@@ -814,6 +747,8 @@ void
 _ebpf_epoch_messenger_propose_release_epoch(
     _Inout_ ebpf_epoch_cpu_entry_t* cpu_entry, _Inout_ ebpf_epoch_cpu_message_t* message, uint32_t current_cpu)
 {
+    // Walk over each thread_entry in the epoch_state_list and compute the minimum epoch.
+    ebpf_list_entry_t* entry = cpu_entry->epoch_state_list.Flink;
     ebpf_epoch_state_t* epoch_state;
     uint32_t next_cpu;
 
@@ -825,18 +760,6 @@ _ebpf_epoch_messenger_propose_release_epoch(
     }
     // Other CPUs update the current epoch.
     else {
-        // If the epoch was unknown, then update the freed_epoch for all items in the free list now that we know the
-        // current epoch. This occurs when the CPU is activated and continues until the first epoch is proposed.
-        if (cpu_entry->current_epoch == EBPF_EPOCH_UNKNOWN_EPOCH) {
-            for (ebpf_list_entry_t* entry = cpu_entry->free_list.Flink; entry != &cpu_entry->free_list;
-                 entry = entry->Flink) {
-                ebpf_epoch_allocation_header_t* header =
-                    CONTAINING_RECORD(entry, ebpf_epoch_allocation_header_t, list_entry);
-                ebpf_assert(header->freed_epoch == EBPF_EPOCH_UNKNOWN_EPOCH);
-                header->freed_epoch = message->message.propose_epoch.current_epoch;
-            }
-        }
-
         cpu_entry->current_epoch = message->message.propose_epoch.current_epoch;
     }
 
@@ -844,24 +767,25 @@ _ebpf_epoch_messenger_propose_release_epoch(
     MemoryBarrier();
 
     // Previous CPU's minimum epoch.
-    int64_t minimum_epoch = message->message.propose_epoch.proposed_release_epoch;
+    uint64_t minimum_epoch = message->message.propose_epoch.proposed_release_epoch;
 
-    // Walk over each thread_entry in the epoch_state_list and compute the minimum epoch.
-    for (ebpf_list_entry_t* entry = &cpu_entry->epoch_state_list; entry != &cpu_entry->epoch_state_list;
-         entry = entry->Flink) {
+    while (entry != &cpu_entry->epoch_state_list) {
         epoch_state = CONTAINING_RECORD(entry, ebpf_epoch_state_t, epoch_list_entry);
         minimum_epoch = min(minimum_epoch, epoch_state->epoch);
+        entry = entry->Flink;
     }
 
     // Set the proposed release epoch to the minimum epoch seen so far.
     message->message.propose_epoch.proposed_release_epoch = minimum_epoch;
 
-    next_cpu = _ebpf_epoch_next_active_cpu(current_cpu);
-
     // If this is the last CPU, then send a message to the first CPU to commit the release epoch.
-    if (next_cpu == 0) {
+    if (current_cpu == _ebpf_epoch_cpu_count - 1) {
         message->message.commit_epoch.released_epoch = minimum_epoch;
         message->message_type = EBPF_EPOCH_CPU_MESSAGE_TYPE_COMMIT_RELEASE_EPOCH;
+        next_cpu = 0;
+    } else {
+        // Send the message to the next CPU.
+        next_cpu = current_cpu + 1;
     }
 
     _ebpf_epoch_send_message_async(message, next_cpu);
@@ -889,41 +813,22 @@ _ebpf_epoch_messenger_commit_release_epoch(
 {
     uint32_t next_cpu;
 
-    // If any epoch_states are in EBPF_EPOCH_UNKNOWN_EPOCH, then activation of a CPU is in progress.
-    bool other_cpus_are_activating = (message->message.commit_epoch.released_epoch == EBPF_EPOCH_UNKNOWN_EPOCH);
-
-    // If this CPU is in EBPF_EPOCH_UNKNOWN_EPOCH, then activation of this CPU is in progress.
-    bool this_cpu_is_activating = (cpu_entry->current_epoch == EBPF_EPOCH_UNKNOWN_EPOCH);
-
     cpu_entry->timer_armed = false;
     // Set the released_epoch to the value computed by the EBPF_EPOCH_CPU_MESSAGE_TYPE_PROPOSE_RELEASE_EPOCH message.
     cpu_entry->released_epoch = message->message.commit_epoch.released_epoch - 1;
 
-    next_cpu = _ebpf_epoch_next_active_cpu(current_cpu);
-
     // If this is the last CPU, send the message to the first CPU to complete the cycle.
-    if (next_cpu == 0) {
+    if (current_cpu != _ebpf_epoch_cpu_count - 1) {
+        // Send the message to the next CPU.
+        next_cpu = current_cpu + 1;
+    } else {
         message->message_type = EBPF_EPOCH_CPU_MESSAGE_TYPE_PROPOSE_EPOCH_COMPLETE;
+        next_cpu = 0;
     }
 
     _ebpf_epoch_send_message_async(message, next_cpu);
 
-    // Wait for all the CPUs to transition to an active state.
-    if (other_cpus_are_activating || this_cpu_is_activating) {
-        // One or more CPUs are still activating. Rearm the timer and wait for the next message.
-        _ebpf_epoch_arm_timer_if_needed(cpu_entry);
-        return;
-    }
-
-    // All CPUs have transitioned to an active state and the epoch computation was successfully completed.
-    // Release any memory that is associated with expired epochs.
     _ebpf_epoch_release_free_list(cpu_entry, cpu_entry->released_epoch);
-
-    // Check if this CPU is idle and deactivate it if it is (CPU 0 is always active).
-    if ((current_cpu != 0) && ebpf_list_is_empty(&cpu_entry->free_list) &&
-        ebpf_list_is_empty(&cpu_entry->epoch_state_list)) {
-        _ebpf_epoch_deactivate_cpu(current_cpu);
-    }
 }
 
 /**
@@ -989,13 +894,15 @@ _ebpf_epoch_messenger_rundown_in_progress(
 {
     uint32_t next_cpu;
     cpu_entry->rundown_in_progress = true;
-
-    next_cpu = _ebpf_epoch_next_active_cpu(current_cpu);
-
     // If this is the last CPU, then stop.
-    if (next_cpu == 0) {
+    if (current_cpu != _ebpf_epoch_cpu_count - 1) {
+        // Send the message to the next CPU.
+        next_cpu = current_cpu + 1;
+    } else {
         // Signal the caller that rundown is complete.
         KeSetEvent(&message->completion_event, 0, FALSE);
+        // Set next_cpu to UINT32_MAX to make code analysis happy.
+        next_cpu = UINT32_MAX;
         return;
     }
 
@@ -1120,90 +1027,4 @@ _ebpf_epoch_work_item_callback(_In_ cxplat_preemptible_work_item_t* preemptible_
     ebpf_free(work_item);
 
     cxplat_release_rundown_protection(&_ebpf_epoch_work_item_rundown_ref);
-}
-
-/**
- * @brief Add the CPU to the next active CPU table.
- *
- * @param[in] cpu_id CPU to add.
- */
-_IRQL_requires_(DISPATCH_LEVEL) static void _ebpf_epoch_activate_cpu(uint32_t cpu_id)
-{
-    EBPF_LOG_ENTRY();
-
-    EBPF_LOG_MESSAGE_UINT64(EBPF_TRACELOG_LEVEL_INFO, EBPF_TRACELOG_KEYWORD_EPOCH, "Activating CPU", cpu_id);
-
-    ebpf_epoch_cpu_entry_t* cpu_entry = &_ebpf_epoch_cpu_table[cpu_id];
-    ebpf_lock_state_t state = ebpf_lock_lock(&_ebpf_epoch_cpu_active_lock);
-
-    ebpf_assert(!cpu_entry->active);
-    ebpf_assert(ebpf_list_is_empty(&cpu_entry->free_list));
-    ebpf_assert(cpu_id == ebpf_get_current_cpu());
-
-    cpu_entry->active = true;
-    // When the CPU is activated, the current epoch is not known.
-    // Memory freed before the current epoch is set will have its epoch set to EBPF_EPOCH_UNKNOWN_EPOCH and have its
-    // epoch set when the current epoch is known (i.e., when the next epoch is proposed).
-    cpu_entry->current_epoch = EBPF_EPOCH_UNKNOWN_EPOCH;
-
-    if (!cpu_entry->work_queue_assigned) {
-        ebpf_result_t result = ebpf_timed_work_queue_set_cpu_id(cpu_entry->work_queue, cpu_id);
-        if (result != EBPF_SUCCESS) {
-            // This is a fatal error. The epoch system is in an inconsistent state.
-            __fastfail(FAST_FAIL_INVALID_ARG);
-        }
-        cpu_entry->work_queue_assigned = 1;
-    }
-
-    ebpf_lock_unlock(&_ebpf_epoch_cpu_active_lock, state);
-    EBPF_LOG_EXIT();
-}
-
-/**
- * @brief Remove the CPU from the next active CPU table.
- *
- * @param[in] cpu_id CPU to remove.
- */
-_IRQL_requires_(DISPATCH_LEVEL) static void _ebpf_epoch_deactivate_cpu(uint32_t cpu_id)
-{
-    EBPF_LOG_ENTRY();
-    ebpf_assert(cpu_id == ebpf_get_current_cpu());
-    ebpf_assert(ebpf_list_is_empty(&_ebpf_epoch_cpu_table[cpu_id].epoch_state_list));
-    ebpf_assert(ebpf_list_is_empty(&_ebpf_epoch_cpu_table[cpu_id].free_list));
-
-    EBPF_LOG_MESSAGE_UINT64(EBPF_TRACELOG_LEVEL_INFO, EBPF_TRACELOG_KEYWORD_EPOCH, "Deactivating CPU", cpu_id);
-
-    ebpf_epoch_cpu_entry_t* cpu_entry = &_ebpf_epoch_cpu_table[cpu_id];
-    ebpf_lock_state_t state = ebpf_lock_lock(&_ebpf_epoch_cpu_active_lock);
-    cpu_entry->active = false;
-    ebpf_lock_unlock(&_ebpf_epoch_cpu_active_lock, state);
-
-    EBPF_LOG_EXIT();
-}
-
-/**
- * @brief Given the current CPU, return the next active CPU.
- *
- * @param[in] cpu_id The current CPU.
- * @return The next active CPU.
- */
-uint32_t
-_ebpf_epoch_next_active_cpu(uint32_t cpu_id)
-{
-    uint32_t next_active_cpu;
-    ebpf_lock_state_t state = ebpf_lock_lock(&_ebpf_epoch_cpu_active_lock);
-
-    for (next_active_cpu = cpu_id + 1; next_active_cpu < _ebpf_epoch_cpu_count; next_active_cpu++) {
-        if (_ebpf_epoch_cpu_table[next_active_cpu].active) {
-            break;
-        }
-    }
-
-    if (next_active_cpu == _ebpf_epoch_cpu_count) {
-        next_active_cpu = 0;
-    }
-
-    ebpf_lock_unlock(&_ebpf_epoch_cpu_active_lock, state);
-
-    return next_active_cpu;
 }

--- a/libs/runtime/ebpf_epoch.h
+++ b/libs/runtime/ebpf_epoch.h
@@ -14,7 +14,7 @@ extern "C"
     typedef struct _ebpf_epoch_state
     {
         LIST_ENTRY epoch_list_entry; /// List entry for the epoch list.
-        int64_t epoch;               /// The epoch when this entry was added to the list.
+        uint64_t epoch;              /// The epoch when this entry was added to the list.
         uint32_t cpu_id;             /// The CPU on which this entry was added to the list.
         KIRQL irql_at_enter;         /// The IRQL when this entry was added to the list.
     } ebpf_epoch_state_t;

--- a/libs/runtime/ebpf_platform.c
+++ b/libs/runtime/ebpf_platform.c
@@ -414,7 +414,7 @@ ebpf_set_current_thread_cpu_affinity(uint32_t cpu_index, _Out_ GROUP_AFFINITY* o
     }
 
     new_affinity.Group = processor.Group;
-    new_affinity.Mask = (ULONG_PTR)1 << processor.Number;
+    new_affinity.Mask = AFFINITY_MASK(processor.Number);
 
     KeSetSystemGroupAffinityThread(&new_affinity, old_cpu_affinity);
 

--- a/libs/runtime/ebpf_platform.c
+++ b/libs/runtime/ebpf_platform.c
@@ -52,12 +52,6 @@ _Requires_lock_held_(*lock) _Releases_lock_(*lock) _IRQL_requires_(DISPATCH_LEVE
     KeReleaseSpinLock(lock, state);
 }
 
-void
-ebpf_restore_current_thread_affinity(uintptr_t old_thread_affinity_mask)
-{
-    KeRevertToUserAffinityThreadEx(old_thread_affinity_mask);
-}
-
 bool
 ebpf_is_preemptible()
 {
@@ -68,7 +62,11 @@ ebpf_is_preemptible()
 uint32_t
 ebpf_get_current_cpu()
 {
-    return KeGetCurrentProcessorNumberEx(NULL);
+    PROCESSOR_NUMBER processor_number;
+
+    KeGetCurrentProcessorNumberEx(&processor_number);
+
+    return KeGetProcessorIndexFromNumber(&processor_number);
 }
 
 uint64_t
@@ -397,43 +395,36 @@ ebpf_log_function(_In_ void* context, _In_z_ const char* format_string, ...)
 }
 
 _Must_inspect_result_ ebpf_result_t
-ebpf_set_current_thread_affinity(uintptr_t new_thread_affinity_mask, _Out_ uintptr_t* old_thread_affinity_mask)
+ebpf_set_current_thread_cpu_affinity(uint32_t cpu_index, _Out_ GROUP_AFFINITY* old_cpu_affinity)
 {
     if (KeGetCurrentIrql() >= DISPATCH_LEVEL) {
         return EBPF_OPERATION_NOT_SUPPORTED;
     }
 
-    KAFFINITY old_affinity = KeSetSystemAffinityThreadEx(new_thread_affinity_mask);
-    *old_thread_affinity_mask = old_affinity;
-    return EBPF_SUCCESS;
-}
-
-_Must_inspect_result_ ebpf_result_t
-ebpf_allocate_non_preemptible_work_item(
-    _Outptr_ KDPC** dpc,
-    uint32_t cpu_id,
-    _In_ PKDEFERRED_ROUTINE work_item_routine,
-    _Inout_opt_ void* work_item_context)
-{
-    *dpc = ebpf_allocate(sizeof(KDPC));
-    if (*dpc == NULL) {
-        return EBPF_NO_MEMORY;
+    if (cpu_index >= ebpf_get_cpu_count()) {
+        return EBPF_INVALID_ARGUMENT;
     }
 
-    KeInitializeDpc(*dpc, work_item_routine, work_item_context);
-    KeSetTargetProcessorDpc(*dpc, (uint8_t)cpu_id);
+    PROCESSOR_NUMBER processor;
+    GROUP_AFFINITY new_affinity = {0};
+
+    NTSTATUS status = KeGetProcessorNumberFromIndex(cpu_index, &processor);
+    if (!NT_SUCCESS(status)) {
+        return EBPF_INVALID_ARGUMENT;
+    }
+
+    new_affinity.Group = processor.Group;
+    new_affinity.Mask = (ULONG_PTR)1 << processor.Number;
+
+    KeSetSystemGroupAffinityThread(&new_affinity, old_cpu_affinity);
+
     return EBPF_SUCCESS;
 }
 
 void
-ebpf_free_non_preemptible_work_item(_In_opt_ _Frees_ptr_opt_ KDPC* dpc)
+ebpf_restore_current_thread_cpu_affinity(_In_ GROUP_AFFINITY* old_cpu_affinity)
 {
-    if (!dpc) {
-        return;
-    }
-
-    KeRemoveQueueDpc(dpc);
-    ebpf_free(dpc);
+    KeRevertToUserGroupAffinityThread(old_cpu_affinity);
 }
 
 typedef struct _ebpf_timer_work_item

--- a/libs/runtime/ebpf_platform.h
+++ b/libs/runtime/ebpf_platform.h
@@ -272,33 +272,6 @@ extern "C"
     ebpf_get_current_thread_id();
 
     /**
-     * @brief Create a non-preemptible work item.
-     *
-     * @param[out] work_item Pointer to memory that will contain the pointer to
-     *  the non-preemptible work item on success.
-     * @param[in] cpu_id Associate the work item with this CPU.
-     * @param[in] work_item_routine Routine to execute as a work item.
-     * @param[in, out] work_item_context Context to pass to the routine.
-     * @retval EBPF_SUCCESS The operation was successful.
-     * @retval EBPF_NO_MEMORY Unable to allocate resources for this
-     *  work item.
-     */
-    _Must_inspect_result_ ebpf_result_t
-    ebpf_allocate_non_preemptible_work_item(
-        _Outptr_ KDPC** work_item,
-        uint32_t cpu_id,
-        _In_ PKDEFERRED_ROUTINE work_item_routine,
-        _Inout_opt_ void* work_item_context);
-
-    /**
-     * @brief Free a non-preemptible work item.
-     *
-     * @param[in] work_item Pointer to the work item to free.
-     */
-    void
-    ebpf_free_non_preemptible_work_item(_In_opt_ _Frees_ptr_opt_ KDPC* work_item);
-
-    /**
      * @brief Create a preemptible work item.
      *
      * @param[out] work_item Pointer to memory that will contain the pointer to
@@ -662,11 +635,24 @@ extern "C"
     uint64_t
     ebpf_query_time_since_boot(bool include_suspended_time);
 
+    /**
+     * @brief Affinitize the current thread to a specific CPU by index and return the old affinity.
+     *
+     * @param[in] cpu_index The index of the CPU to affinitize to.
+     * @param[out] old_cpu_affinity The old CPU affinity.
+     * @retval EBPF_SUCCESS The operation was successful.
+     * @retval EBPF_INVALID_ARGUMENT The CPU index is invalid.
+     */
     _Must_inspect_result_ ebpf_result_t
-    ebpf_set_current_thread_affinity(uintptr_t new_thread_affinity_mask, _Out_ uintptr_t* old_thread_affinity_mask);
+    ebpf_set_current_thread_cpu_affinity(uint32_t cpu_index, _Out_ GROUP_AFFINITY* old_cpu_affinity);
 
+    /**
+     * @brief Restore the CPU affinity of the current thread to the previous affinity.
+     *
+     * @param[in] old_cpu_affinity The previous CPU affinity.
+     */
     void
-    ebpf_restore_current_thread_affinity(uintptr_t old_thread_affinity_mask);
+    ebpf_restore_current_thread_cpu_affinity(_In_ GROUP_AFFINITY* old_cpu_affinity);
 
     typedef _Return_type_success_(return >= 0) LONG NTSTATUS;
 

--- a/libs/runtime/ebpf_platform.h
+++ b/libs/runtime/ebpf_platform.h
@@ -29,6 +29,10 @@ extern "C"
 #define EBPF_INLINE_HINT
 #endif
 
+#if !defined(AFFINITY_MASK)
+#define AFFINITY_MASK(n) ((ULONG_PTR)1 << (n))
+#endif
+
 #define EBPF_UTF8_STRING_FROM_CONST_STRING(x) \
     {                                         \
         ((uint8_t*)(x)), sizeof((x)) - 1      \

--- a/libs/runtime/ebpf_platform.h
+++ b/libs/runtime/ebpf_platform.h
@@ -30,7 +30,7 @@ extern "C"
 #endif
 
 #if !defined(AFFINITY_MASK)
-#define AFFINITY_MASK(n) ((ULONG_PTR)1 << (n))
+#define AFFINITY_MASK(n) ((ULONG_PTR)(1) << (n))
 #endif
 
 #define EBPF_UTF8_STRING_FROM_CONST_STRING(x) \

--- a/libs/runtime/ebpf_work_queue.h
+++ b/libs/runtime/ebpf_work_queue.h
@@ -49,17 +49,6 @@ extern "C"
         _In_ void* context);
 
     /**
-     * @brief Set the CPU ID for the timed work queue.
-     *
-     * @param[in] work_queue Work queue to set the CPU ID for.
-     * @param[in] cpu_id Which CPU to run the work queue on.
-     * @retval EBPF_SUCCESS The operation was successful.
-     * @retval EBPF_INVALID_ARGUMENT The CPU ID is invalid.
-     */
-    _Must_inspect_result_ ebpf_result_t
-    ebpf_timed_work_queue_set_cpu_id(_Inout_ ebpf_timed_work_queue_t* work_queue, uint32_t cpu_id);
-
-    /**
      * @brief Destroy a timed work queue.
      *
      * @param[in] work_queue The timed work queue to destroy.

--- a/tests/end_to_end/end_to_end.cpp
+++ b/tests/end_to_end/end_to_end.cpp
@@ -1381,9 +1381,9 @@ TEST_CASE("map_pinning_test", "[end_to_end]")
         bpf_map__unpin(bpf_object__find_map_by_name(unique_object.get(), "limits_map"), limit_maps_name.c_str()) ==
         EBPF_SUCCESS);
 
-    REQUIRE(bpf_obj_get(limit_maps_name.c_str()) == ebpf_fd_invalid);
+    REQUIRE(bpf_obj_get(limit_maps_name.c_str()) == -ENOENT);
 
-    REQUIRE(bpf_obj_get(process_maps_name.c_str()) == ebpf_fd_invalid);
+    REQUIRE(bpf_obj_get(process_maps_name.c_str()) == -ENOENT);
 
     bpf_object__close(unique_object.release());
 }

--- a/tests/end_to_end/helpers.h
+++ b/tests/end_to_end/helpers.h
@@ -76,19 +76,18 @@ typedef class _emulate_dpc
   public:
     _emulate_dpc(uint32_t cpu_id)
     {
-        uintptr_t new_thread_affinity_mask = 1ull << cpu_id;
-        ebpf_assert_success(ebpf_set_current_thread_affinity(new_thread_affinity_mask, &old_thread_affinity_mask));
+        ebpf_assert_success(ebpf_set_current_thread_cpu_affinity(cpu_id, &old_thread_affinity_mask));
         KeRaiseIrql(DISPATCH_LEVEL, &old_irql);
     }
     ~_emulate_dpc()
     {
         KeLowerIrql(old_irql);
 
-        ebpf_restore_current_thread_affinity(old_thread_affinity_mask);
+        ebpf_restore_current_thread_cpu_affinity(&old_thread_affinity_mask);
     }
 
   private:
-    uintptr_t old_thread_affinity_mask;
+    GROUP_AFFINITY old_thread_affinity_mask;
     KIRQL old_irql;
 
 } emulate_dpc_t;

--- a/tests/unit/libbpf_test.cpp
+++ b/tests/unit/libbpf_test.cpp
@@ -600,7 +600,7 @@ TEST_CASE("libbpf program pinning", "[libbpf]")
     REQUIRE(obj_fd != ebpf_fd_invalid);
     REQUIRE(errno == EEXIST);
     obj_fd = bpf_obj_get(bad_pin_path);
-    REQUIRE(obj_fd == ebpf_fd_invalid);
+    REQUIRE(obj_fd == -ENOENT);
     REQUIRE(errno == ENOENT);
 
     result = bpf_program__unpin(program, pin_path);
@@ -846,7 +846,7 @@ TEST_CASE("libbpf map", "[libbpf]")
 
     int result = bpf_map_lookup_elem(map_fd, &index, &value);
     REQUIRE(result < 0);
-    REQUIRE(errno == EINVAL);
+    REQUIRE(errno == ENOENT);
 
     // Wrong fd type.
     int program_fd = bpf_program__fd(const_cast<const bpf_program*>(program));


### PR DESCRIPTION
## Description

This pull request includes several changes to improve the handling of CPU affinity in the eBPF platform. The most significant changes involve updating the data type for thread affinity and refactoring related functions for setting and restoring CPU affinity.

Changes to CPU affinity handling:

* [`libs/execution_context/ebpf_program.c`](diffhunk://#diff-6bd70efed6714c9e250113aa729f24539066345c2433fccee1928c62f6657320L2392-R2392): Updated the type of `old_thread_affinity` from `uintptr_t` to `GROUP_AFFINITY` and refactored related function calls to use `ebpf_set_current_thread_cpu_affinity` and `ebpf_restore_current_thread_cpu_affinity`. [[1]](diffhunk://#diff-6bd70efed6714c9e250113aa729f24539066345c2433fccee1928c62f6657320L2392-R2392) [[2]](diffhunk://#diff-6bd70efed6714c9e250113aa729f24539066345c2433fccee1928c62f6657320L2403-R2403) [[3]](diffhunk://#diff-6bd70efed6714c9e250113aa729f24539066345c2433fccee1928c62f6657320L2504-R2504)

Function removal and refactoring:

* [`libs/runtime/ebpf_platform.c`](diffhunk://#diff-9dfbd58f5d316f64d047f68fc95883ef97c3c0b586a6a7e35a6835f3d3f0e4deL55-L60): Removed the `ebpf_restore_current_thread_affinity` function and replaced it with `ebpf_restore_current_thread_cpu_affinity`. Refactored `ebpf_set_current_thread_affinity` to `ebpf_set_current_thread_cpu_affinity` and updated its implementation to use `GROUP_AFFINITY`. [[1]](diffhunk://#diff-9dfbd58f5d316f64d047f68fc95883ef97c3c0b586a6a7e35a6835f3d3f0e4deL55-L60) [[2]](diffhunk://#diff-9dfbd58f5d316f64d047f68fc95883ef97c3c0b586a6a7e35a6835f3d3f0e4deL71-R69) [[3]](diffhunk://#diff-9dfbd58f5d316f64d047f68fc95883ef97c3c0b586a6a7e35a6835f3d3f0e4deL400-R427)
* [`libs/runtime/ebpf_platform.h`](diffhunk://#diff-2d8c1d862f7672b2b1bd853a82d62da9a2ce750835eaecca82b992a542dd31a7L274-L300): Removed declarations for `ebpf_allocate_non_preemptible_work_item` and `ebpf_free_non_preemptible_work_item`. Added declarations for `ebpf_set_current_thread_cpu_affinity` and `ebpf_restore_current_thread_cpu_affinity`. [[1]](diffhunk://#diff-2d8c1d862f7672b2b1bd853a82d62da9a2ce750835eaecca82b992a542dd31a7L274-L300) [[2]](diffhunk://#diff-2d8c1d862f7672b2b1bd853a82d62da9a2ce750835eaecca82b992a542dd31a7R638-R655)

Test updates:

* [`libs/runtime/unit/platform_unit_test.cpp`](diffhunk://#diff-d6862842c025074e8e82d80bb16d5620a8bb3a444d6d7f985b41609b8d47d6b6L575-R594): Updated test cases to use the new `GROUP_AFFINITY` type and the refactored CPU affinity functions.
* [`tests/end_to_end/helpers.h`](diffhunk://#diff-fe13f0b69714aa7bc379f52a56fb6db6a732801eab54a98e260279e649c4d04cL79-R90): Refactored the `_emulate_dpc` class to use the new CPU affinity functions and `GROUP_AFFINITY` type.

Submodule update:

* [`external/usersim`](diffhunk://#diff-4ae78540d77e146774e537be8c7888b0e96d803c98c06760e4e8775833905812L1-R1): Updated the submodule commit reference.

## Testing

CI/CD

## Documentation

No.

## Installation

No.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced CPU affinity management for improved thread handling.
	- Introduced functions for setting and restoring CPU affinity using structured types.

- **Bug Fixes**
	- Improved error handling and resource cleanup in thread affinity management.

- **Refactor**
	- Streamlined code structure and removed redundant functions related to non-preemptible work items.
	- Updated test cases to ensure accurate management of thread affinities.

- **Documentation**
	- Updated header files to reflect changes in function signatures and removed functions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->