### PR TITLE
Approximate time helpers

### DIFF
--- a/include/bpf_helper_defs.h
+++ b/include/bpf_helper_defs.h
@@ -473,3 +473,25 @@ EBPF_HELPER(size_t, bpf_strnlen_s, (const char* str, size_t str_size));
 #define memcpy_s bpf_memcpy
 #define memmove_s bpf_memmove
 #endif
+
+/**
+ * @brief Return time elapsed since boot in milliseconds including time while suspended.
+ * This function uses a lower resolution clock source than bpf_ktime_get_boot_ns, but is faster.
+ *
+ * @return Time elapsed since boot in milliseconds units.
+ */
+EBPF_HELPER(uint64_t, bpf_ktime_get_boot_ms, ());
+#ifndef __doxygen
+#define bpf_ktime_get_boot_ms ((bpf_ktime_get_boot_ms_t)BPF_FUNC_ktime_get_boot_ms)
+#endif
+
+/**
+ * @brief Return time elapsed since boot in milliseconds excluding time while suspended.
+ * This function uses a lower resolution clock source than bpf_ktime_get_ns, but is faster.
+ *
+ * @return Time elapsed since boot in milliseconds units.
+ */
+EBPF_HELPER(uint64_t, bpf_ktime_get_ms, ());
+#ifndef __doxygen
+#define bpf_ktime_get_ms ((bpf_ktime_get_ns_t)BPF_FUNC_ktime_get_ms)
+#endif

--- a/include/bpf_helper_defs.h
+++ b/include/bpf_helper_defs.h
@@ -493,5 +493,5 @@ EBPF_HELPER(uint64_t, bpf_ktime_get_boot_ms, ());
  */
 EBPF_HELPER(uint64_t, bpf_ktime_get_ms, ());
 #ifndef __doxygen
-#define bpf_ktime_get_ms ((bpf_ktime_get_ns_t)BPF_FUNC_ktime_get_ms)
+#define bpf_ktime_get_ms ((bpf_ktime_get_ms_t)BPF_FUNC_ktime_get_ms)
 #endif

--- a/include/ebpf_structs.h
+++ b/include/ebpf_structs.h
@@ -164,6 +164,8 @@ typedef enum
     BPF_FUNC_strncpy_s = 27,                 ///< \ref bpf_strncpy_s
     BPF_FUNC_strncat_s = 28,                 ///< \ref bpf_strncat_s
     BPF_FUNC_strnlen_s = 29,                 ///< \ref bpf_strnlen_s
+    BPF_FUNC_ktime_get_boot_ms = 30,         ///< \ref bpf_ktime_get_boot_ms
+    BPF_FUNC_ktime_get_ms = 31,              ///< \ref bpf_ktime_get_ms
 } ebpf_helper_id_t;
 
 // Cross-platform BPF program types.

--- a/libs/execution_context/ebpf_core.c
+++ b/libs/execution_context/ebpf_core.c
@@ -101,6 +101,12 @@ _ebpf_core_memmove(
     _In_reads_(source_length) const void* source,
     size_t source_length);
 
+static uint64_t
+_ebpf_core_get_time_since_boot_ms();
+
+static uint64_t
+_ebpf_core_get_time_ms();
+
 #define EBPF_CORE_GLOBAL_HELPER_EXTENSION_VERSION 0
 
 static ebpf_program_type_descriptor_t _ebpf_global_helper_program_descriptor = {
@@ -144,6 +150,8 @@ static const void* _ebpf_general_helpers[] = {
     (void*)&_ebpf_core_strncpy_s,
     (void*)&_ebpf_core_strncat_s,
     (void*)&_ebpf_core_strlen_s,
+    (void*)&_ebpf_core_get_time_since_boot_ms,
+    (void*)&_ebpf_core_get_time_ms,
 };
 
 static const ebpf_helper_function_addresses_t _ebpf_global_helper_function_dispatch_table = {
@@ -2178,17 +2186,33 @@ _ebpf_core_random_uint32()
 static uint64_t
 _ebpf_core_get_time_since_boot_ns()
 {
-    // ebpf_query_time_since_boot_precise returns time elapsed since
+    // cxplat_query_time_since_boot_precise returns time elapsed since
     // boot in units of 100 ns.
-    return ebpf_query_time_since_boot_precise(true) * EBPF_NS_PER_FILETIME;
+    return cxplat_query_time_since_boot_precise(true) * EBPF_NS_PER_FILETIME;
 }
 
 static uint64_t
 _ebpf_core_get_time_ns()
 {
-    // ebpf_query_time_since_boot_precise returns time elapsed since
+    // cxplat_query_time_since_boot_precise returns time elapsed since
     // boot in units of 100 ns.
-    return ebpf_query_time_since_boot_precise(false) * EBPF_NS_PER_FILETIME;
+    return cxplat_query_time_since_boot_approximate(false) / EBPF_FILETIME_PER_MS;
+}
+
+static uint64_t
+_ebpf_core_get_time_since_boot_ms()
+{
+    // cxplat_query_time_since_boot_approximate returns time elapsed since
+    // boot in units of 100 ns.
+    return cxplat_query_time_since_boot_approximate(true) / EBPF_FILETIME_PER_MS;
+}
+
+static uint64_t
+_ebpf_core_get_time_ms()
+{
+    // cxplat_query_time_since_boot_approximate returns time elapsed since
+    // boot in units of 100 ns.
+    return cxplat_query_time_since_boot_approximate(false) * EBPF_NS_PER_FILETIME;
 }
 
 static uint64_t

--- a/libs/execution_context/ebpf_core.c
+++ b/libs/execution_context/ebpf_core.c
@@ -2196,7 +2196,7 @@ _ebpf_core_get_time_ns()
 {
     // cxplat_query_time_since_boot_precise returns time elapsed since
     // boot in units of 100 ns.
-    return cxplat_query_time_since_boot_approximate(false) / EBPF_FILETIME_PER_MS;
+    return cxplat_query_time_since_boot_precise(false) * EBPF_NS_PER_FILETIME;
 }
 
 static uint64_t
@@ -2212,7 +2212,7 @@ _ebpf_core_get_time_ms()
 {
     // cxplat_query_time_since_boot_approximate returns time elapsed since
     // boot in units of 100 ns.
-    return cxplat_query_time_since_boot_approximate(false) * EBPF_NS_PER_FILETIME;
+    return cxplat_query_time_since_boot_approximate(false) / EBPF_FILETIME_PER_MS;
 }
 
 static uint64_t

--- a/libs/execution_context/ebpf_general_helpers.c
+++ b/libs/execution_context/ebpf_general_helpers.c
@@ -197,6 +197,12 @@ ebpf_helper_function_prototype_t ebpf_core_helper_function_prototype_array[] = {
          EBPF_ARGUMENT_TYPE_PTR_TO_READABLE_MEM,
          EBPF_ARGUMENT_TYPE_CONST_SIZE_OR_ZERO,
      }},
+    {EBPF_HELPER_FUNCTION_PROTOTYPE_HEADER,
+     BPF_FUNC_ktime_get_boot_ms,
+     "bpf_ktime_get_boot_ms",
+     EBPF_RETURN_TYPE_INTEGER,
+     {0}},
+    {EBPF_HELPER_FUNCTION_PROTOTYPE_HEADER, BPF_FUNC_ktime_get_ms, "bpf_ktime_get_ms", EBPF_RETURN_TYPE_INTEGER, {0}},
 };
 
 #ifdef __cplusplus

--- a/libs/execution_context/ebpf_maps.c
+++ b/libs/execution_context/ebpf_maps.c
@@ -1205,7 +1205,7 @@ _insert_into_hot_list(_Inout_ ebpf_core_lru_map_t* map, size_t partition, _Inout
     switch (key_state) {
     case EBPF_LRU_KEY_UNINITIALIZED:
         EBPF_LRU_ENTRY_GENERATION_PTR(map, entry)[partition] = map->partitions[partition].current_generation;
-        EBPF_LRU_ENTRY_LAST_USED_TIME_PTR(map, entry)[partition] = ebpf_query_time_since_boot_approximate(false);
+        EBPF_LRU_ENTRY_LAST_USED_TIME_PTR(map, entry)[partition] = cxplat_query_time_since_boot_approximate(false);
         ebpf_list_insert_tail(
             &map->partitions[partition].hot_list, &EBPF_LRU_ENTRY_LIST_ENTRY_PTR(map, entry)[partition]);
         map->partitions[partition].hot_list_size++;
@@ -1213,7 +1213,7 @@ _insert_into_hot_list(_Inout_ ebpf_core_lru_map_t* map, size_t partition, _Inout
     case EBPF_LRU_KEY_COLD:
         // Remove from cold list.
         EBPF_LRU_ENTRY_GENERATION_PTR(map, entry)[partition] = map->partitions[partition].current_generation;
-        EBPF_LRU_ENTRY_LAST_USED_TIME_PTR(map, entry)[partition] = ebpf_query_time_since_boot_approximate(false);
+        EBPF_LRU_ENTRY_LAST_USED_TIME_PTR(map, entry)[partition] = cxplat_query_time_since_boot_approximate(false);
         ebpf_list_remove_entry(&EBPF_LRU_ENTRY_LIST_ENTRY_PTR(map, entry)[partition]);
         ebpf_list_insert_tail(
             &map->partitions[partition].hot_list, &EBPF_LRU_ENTRY_LIST_ENTRY_PTR(map, entry)[partition]);
@@ -1257,7 +1257,7 @@ _initialize_lru_entry(
     // Only insert into the current partition's hot list.
     ebpf_lock_state_t state = ebpf_lock_lock(&map->partitions[partition].lock);
     EBPF_LRU_ENTRY_GENERATION_PTR(map, entry)[partition] = map->partitions[partition].current_generation;
-    EBPF_LRU_ENTRY_LAST_USED_TIME_PTR(map, entry)[partition] = ebpf_query_time_since_boot_approximate(false);
+    EBPF_LRU_ENTRY_LAST_USED_TIME_PTR(map, entry)[partition] = cxplat_query_time_since_boot_approximate(false);
     ebpf_list_insert_tail(&map->partitions[partition].hot_list, &EBPF_LRU_ENTRY_LIST_ENTRY_PTR(map, entry)[partition]);
     map->partitions[partition].hot_list_size++;
 

--- a/libs/execution_context/ebpf_program.c
+++ b/libs/execution_context/ebpf_program.c
@@ -2435,7 +2435,7 @@ _ebpf_program_test_run_work_item(_In_ cxplat_preemptible_work_item_t* work_item,
         state_stored = true;
     }
 
-    uint64_t start_time = ebpf_query_time_since_boot_precise(false);
+    uint64_t start_time = cxplat_query_time_since_boot_precise(false);
     // Use a counter instead of performing a modulus operation to determine when to start a new epoch.
     // This is because the modulus operation is expensive and we want to minimize the overhead of
     // the test run.
@@ -2448,7 +2448,7 @@ _ebpf_program_test_run_work_item(_In_ cxplat_preemptible_work_item_t* work_item,
             ebpf_epoch_exit(&epoch_state);
             if (ebpf_should_yield_processor()) {
                 // Compute the elapsed time since the last yield.
-                end_time = ebpf_query_time_since_boot_precise(false);
+                end_time = cxplat_query_time_since_boot_precise(false);
 
                 // Add the elapsed time to the cumulative time.
                 cumulative_time += end_time - start_time;
@@ -2460,7 +2460,7 @@ _ebpf_program_test_run_work_item(_In_ cxplat_preemptible_work_item_t* work_item,
                 old_irql = ebpf_raise_irql(context->required_irql);
 
                 // Reset the start time.
-                start_time = ebpf_query_time_since_boot_precise(false);
+                start_time = cxplat_query_time_since_boot_precise(false);
             }
             ebpf_epoch_enter(&epoch_state);
         }
@@ -2470,7 +2470,7 @@ _ebpf_program_test_run_work_item(_In_ cxplat_preemptible_work_item_t* work_item,
             break;
         }
     }
-    end_time = ebpf_query_time_since_boot_precise(false);
+    end_time = cxplat_query_time_since_boot_precise(false);
 
     cumulative_time += end_time - start_time;
 

--- a/libs/runtime/ebpf_platform.c
+++ b/libs/runtime/ebpf_platform.c
@@ -220,34 +220,6 @@ ebpf_allocate_process_state()
     return state;
 }
 
-uint64_t
-ebpf_query_time_since_boot_precise(bool include_suspended_time)
-{
-    uint64_t qpc_time;
-    if (include_suspended_time) {
-        // KeQueryUnbiasedInterruptTimePrecise returns the current interrupt-time count in 100-nanosecond units.
-        // Unbiased Interrupt time is the total time since boot including time spent suspended.
-        // https://docs.microsoft.com/en-us/windows-hardware/drivers/ddi/wdm/nf-wdm-kequeryunbiasedinterrupttimeprecise
-        return KeQueryUnbiasedInterruptTimePrecise(&qpc_time);
-    } else {
-        // KeQueryInterruptTimePrecise returns the current interrupt-time count in 100-nanosecond units.
-        // (Biased) Interrupt time is the total time since boot excluding time spent suspended.        //
-        // https://docs.microsoft.com/en-us/windows-hardware/drivers/ddi/wdm/nf-wdm-kequeryinterrupttimeprecise
-        return KeQueryInterruptTimePrecise(&qpc_time);
-    }
-}
-
-uint64_t
-ebpf_query_time_since_boot_approximate(bool include_suspend_time)
-{
-    if (include_suspend_time) {
-        ebpf_assert(!"Include suspend time not supported on this platform.");
-        return 0;
-    } else {
-        return KeQueryInterruptTime();
-    }
-}
-
 MDL*
 ebpf_map_memory(size_t length)
 {

--- a/libs/runtime/ebpf_platform.h
+++ b/libs/runtime/ebpf_platform.h
@@ -39,6 +39,7 @@ extern "C"
     }
 
 #define EBPF_NS_PER_FILETIME 100
+#define EBPF_FILETIME_PER_MS 10000
 
     typedef enum _ebpf_code_integrity_state
     {
@@ -645,29 +646,6 @@ extern "C"
     _Must_inspect_result_ ebpf_result_t
     ebpf_validate_security_descriptor(
         _In_ const ebpf_security_descriptor_t* security_descriptor, size_t security_descriptor_length);
-
-    /**
-     * @brief Return time elapsed since boot in units of 100 nanoseconds.
-     *
-     * @param[in] include_suspended_time Include time the system spent in a suspended state.
-     * @return Time elapsed since boot in 100 nanosecond units.
-     */
-    EBPF_INLINE_HINT
-    uint64_t
-    ebpf_query_time_since_boot_precise(bool include_suspended_time);
-
-    /**
-     * @brief Return time elapsed since boot in units of 100 nanoseconds.
-     * This function is faster than ebpf_query_time_since_boot_precise() but may not
-     * be as accurate.
-     *
-     * @param[in] include_suspended_time Include time the system spent in a suspended state.
-     *
-     * @return Time elapsed since boot in 100 nanosecond units.
-     */
-    EBPF_INLINE_HINT
-    uint64_t
-    ebpf_query_time_since_boot_approximate(bool include_suspended_time);
 
     /**
      * @brief Affinitize the current thread to a specific CPU by index and return the old affinity.

--- a/tests/bpf2c_tests/expected/test_utility_helpers_dll.c
+++ b/tests/bpf2c_tests/expected/test_utility_helpers_dll.c
@@ -45,7 +45,7 @@ static map_entry_t _maps[] = {
      {
          BPF_MAP_TYPE_ARRAY, // Type of map.
          4,                  // Size in bytes of a map key.
-         40,                 // Size in bytes of a map value.
+         56,                 // Size in bytes of a map value.
          2,                  // Maximum number of entries allowed in the map.
          0,                  // Inner map index.
          LIBBPF_PIN_NONE,    // Pinning type for the map.
@@ -69,6 +69,8 @@ static helper_function_entry_t test_utility_helpers_helpers[] = {
     {NULL, 9, "helper_id_9"},
     {NULL, 8, "helper_id_8"},
     {NULL, 19, "helper_id_19"},
+    {NULL, 30, "helper_id_30"},
+    {NULL, 31, "helper_id_31"},
     {NULL, 2, "helper_id_2"},
 };
 
@@ -120,18 +122,18 @@ test_utility_helpers(void* context)
     // EBPF_OP_MOV64_IMM pc=3 dst=r1 src=r0 offset=0 imm=0
 #line 12 "sample/./sample_common_routines.h"
     r1 = IMMEDIATE(0);
-    // EBPF_OP_STXDW pc=4 dst=r10 src=r1 offset=-24 imm=0
-#line 13 "sample/./sample_common_routines.h"
-    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-24)) = (uint64_t)r1;
-    // EBPF_OP_STXDW pc=5 dst=r10 src=r1 offset=-32 imm=0
-#line 13 "sample/./sample_common_routines.h"
-    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-32)) = (uint64_t)r1;
-    // EBPF_OP_STXDW pc=6 dst=r10 src=r1 offset=-40 imm=0
+    // EBPF_OP_STXDW pc=4 dst=r10 src=r1 offset=-40 imm=0
 #line 13 "sample/./sample_common_routines.h"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-40)) = (uint64_t)r1;
-    // EBPF_OP_STXDW pc=7 dst=r10 src=r1 offset=-48 imm=0
+    // EBPF_OP_STXDW pc=5 dst=r10 src=r1 offset=-48 imm=0
 #line 13 "sample/./sample_common_routines.h"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-48)) = (uint64_t)r1;
+    // EBPF_OP_STXDW pc=6 dst=r10 src=r1 offset=-56 imm=0
+#line 13 "sample/./sample_common_routines.h"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-56)) = (uint64_t)r1;
+    // EBPF_OP_STXDW pc=7 dst=r10 src=r1 offset=-64 imm=0
+#line 13 "sample/./sample_common_routines.h"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-64)) = (uint64_t)r1;
     // EBPF_OP_CALL pc=8 dst=r0 src=r0 offset=0 imm=6
 #line 16 "sample/./sample_common_routines.h"
     r0 = test_utility_helpers_helpers[0].address(r1, r2, r3, r4, r5, context);
@@ -141,9 +143,9 @@ test_utility_helpers(void* context)
         return 0;
 #line 16 "sample/./sample_common_routines.h"
     }
-    // EBPF_OP_STXW pc=9 dst=r10 src=r0 offset=-48 imm=0
+    // EBPF_OP_STXW pc=9 dst=r10 src=r0 offset=-64 imm=0
 #line 16 "sample/./sample_common_routines.h"
-    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-48)) = (uint32_t)r0;
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-64)) = (uint32_t)r0;
     // EBPF_OP_CALL pc=10 dst=r0 src=r0 offset=0 imm=7
 #line 24 "sample/./sample_common_routines.h"
     r0 = test_utility_helpers_helpers[1].address(r1, r2, r3, r4, r5, context);
@@ -153,9 +155,9 @@ test_utility_helpers(void* context)
         return 0;
 #line 24 "sample/./sample_common_routines.h"
     }
-    // EBPF_OP_STXDW pc=11 dst=r10 src=r0 offset=-32 imm=0
+    // EBPF_OP_STXDW pc=11 dst=r10 src=r0 offset=-48 imm=0
 #line 24 "sample/./sample_common_routines.h"
-    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-32)) = (uint64_t)r0;
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-48)) = (uint64_t)r0;
     // EBPF_OP_CALL pc=12 dst=r0 src=r0 offset=0 imm=9
 #line 27 "sample/./sample_common_routines.h"
     r0 = test_utility_helpers_helpers[2].address(r1, r2, r3, r4, r5, context);
@@ -165,9 +167,9 @@ test_utility_helpers(void* context)
         return 0;
 #line 27 "sample/./sample_common_routines.h"
     }
-    // EBPF_OP_STXDW pc=13 dst=r10 src=r0 offset=-40 imm=0
+    // EBPF_OP_STXDW pc=13 dst=r10 src=r0 offset=-56 imm=0
 #line 27 "sample/./sample_common_routines.h"
-    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-40)) = (uint64_t)r0;
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-56)) = (uint64_t)r0;
     // EBPF_OP_CALL pc=14 dst=r0 src=r0 offset=0 imm=8
 #line 30 "sample/./sample_common_routines.h"
     r0 = test_utility_helpers_helpers[3].address(r1, r2, r3, r4, r5, context);
@@ -177,9 +179,9 @@ test_utility_helpers(void* context)
         return 0;
 #line 30 "sample/./sample_common_routines.h"
     }
-    // EBPF_OP_STXW pc=15 dst=r10 src=r0 offset=-24 imm=0
+    // EBPF_OP_STXW pc=15 dst=r10 src=r0 offset=-40 imm=0
 #line 30 "sample/./sample_common_routines.h"
-    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-24)) = (uint32_t)r0;
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-40)) = (uint32_t)r0;
     // EBPF_OP_CALL pc=16 dst=r0 src=r0 offset=0 imm=19
 #line 33 "sample/./sample_common_routines.h"
     r0 = test_utility_helpers_helpers[4].address(r1, r2, r3, r4, r5, context);
@@ -189,115 +191,163 @@ test_utility_helpers(void* context)
         return 0;
 #line 33 "sample/./sample_common_routines.h"
     }
-    // EBPF_OP_STXDW pc=17 dst=r10 src=r0 offset=-16 imm=0
+    // EBPF_OP_STXDW pc=17 dst=r10 src=r0 offset=-32 imm=0
 #line 33 "sample/./sample_common_routines.h"
-    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint64_t)r0;
-    // EBPF_OP_MOV64_REG pc=18 dst=r2 src=r10 offset=0 imm=0
-#line 33 "sample/./sample_common_routines.h"
-    r2 = r10;
-    // EBPF_OP_ADD64_IMM pc=19 dst=r2 src=r0 offset=0 imm=-8
-#line 33 "sample/./sample_common_routines.h"
-    r2 += IMMEDIATE(-8);
-    // EBPF_OP_MOV64_REG pc=20 dst=r6 src=r10 offset=0 imm=0
-#line 33 "sample/./sample_common_routines.h"
-    r6 = r10;
-    // EBPF_OP_ADD64_IMM pc=21 dst=r6 src=r0 offset=0 imm=-48
-#line 33 "sample/./sample_common_routines.h"
-    r6 += IMMEDIATE(-48);
-    // EBPF_OP_LDDW pc=22 dst=r1 src=r1 offset=0 imm=1
-#line 36 "sample/./sample_common_routines.h"
-    r1 = POINTER(_maps[0].address);
-    // EBPF_OP_MOV64_REG pc=24 dst=r3 src=r6 offset=0 imm=0
-#line 36 "sample/./sample_common_routines.h"
-    r3 = r6;
-    // EBPF_OP_MOV64_IMM pc=25 dst=r4 src=r0 offset=0 imm=0
-#line 36 "sample/./sample_common_routines.h"
-    r4 = IMMEDIATE(0);
-    // EBPF_OP_CALL pc=26 dst=r0 src=r0 offset=0 imm=2
-#line 36 "sample/./sample_common_routines.h"
-    r0 = test_utility_helpers_helpers[5].address(r1, r2, r3, r4, r5, context);
-#line 36 "sample/./sample_common_routines.h"
-    if ((test_utility_helpers_helpers[5].tail_call) && (r0 == 0)) {
-#line 36 "sample/./sample_common_routines.h"
-        return 0;
-#line 36 "sample/./sample_common_routines.h"
-    }
-    // EBPF_OP_CALL pc=27 dst=r0 src=r0 offset=0 imm=6
-#line 39 "sample/./sample_common_routines.h"
-    r0 = test_utility_helpers_helpers[0].address(r1, r2, r3, r4, r5, context);
-#line 39 "sample/./sample_common_routines.h"
-    if ((test_utility_helpers_helpers[0].tail_call) && (r0 == 0)) {
-#line 39 "sample/./sample_common_routines.h"
-        return 0;
-#line 39 "sample/./sample_common_routines.h"
-    }
-    // EBPF_OP_STXW pc=28 dst=r10 src=r0 offset=-48 imm=0
-#line 39 "sample/./sample_common_routines.h"
-    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-48)) = (uint32_t)r0;
-    // EBPF_OP_CALL pc=29 dst=r0 src=r0 offset=0 imm=9
-#line 42 "sample/./sample_common_routines.h"
-    r0 = test_utility_helpers_helpers[2].address(r1, r2, r3, r4, r5, context);
-#line 42 "sample/./sample_common_routines.h"
-    if ((test_utility_helpers_helpers[2].tail_call) && (r0 == 0)) {
-#line 42 "sample/./sample_common_routines.h"
-        return 0;
-#line 42 "sample/./sample_common_routines.h"
-    }
-    // EBPF_OP_STXDW pc=30 dst=r10 src=r0 offset=-40 imm=0
-#line 42 "sample/./sample_common_routines.h"
-    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-40)) = (uint64_t)r0;
-    // EBPF_OP_CALL pc=31 dst=r0 src=r0 offset=0 imm=7
-#line 45 "sample/./sample_common_routines.h"
-    r0 = test_utility_helpers_helpers[1].address(r1, r2, r3, r4, r5, context);
-#line 45 "sample/./sample_common_routines.h"
-    if ((test_utility_helpers_helpers[1].tail_call) && (r0 == 0)) {
-#line 45 "sample/./sample_common_routines.h"
-        return 0;
-#line 45 "sample/./sample_common_routines.h"
-    }
-    // EBPF_OP_STXDW pc=32 dst=r10 src=r0 offset=-32 imm=0
-#line 45 "sample/./sample_common_routines.h"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-32)) = (uint64_t)r0;
-    // EBPF_OP_CALL pc=33 dst=r0 src=r0 offset=0 imm=19
-#line 48 "sample/./sample_common_routines.h"
-    r0 = test_utility_helpers_helpers[4].address(r1, r2, r3, r4, r5, context);
-#line 48 "sample/./sample_common_routines.h"
-    if ((test_utility_helpers_helpers[4].tail_call) && (r0 == 0)) {
-#line 48 "sample/./sample_common_routines.h"
-        return 0;
-#line 48 "sample/./sample_common_routines.h"
-    }
-    // EBPF_OP_STXDW pc=34 dst=r10 src=r0 offset=-16 imm=0
-#line 48 "sample/./sample_common_routines.h"
-    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint64_t)r0;
-    // EBPF_OP_MOV64_REG pc=35 dst=r2 src=r10 offset=0 imm=0
-#line 51 "sample/./sample_common_routines.h"
-    r2 = r10;
-    // EBPF_OP_ADD64_IMM pc=36 dst=r2 src=r0 offset=0 imm=-4
-#line 51 "sample/./sample_common_routines.h"
-    r2 += IMMEDIATE(-4);
-    // EBPF_OP_LDDW pc=37 dst=r1 src=r1 offset=0 imm=1
-#line 51 "sample/./sample_common_routines.h"
-    r1 = POINTER(_maps[0].address);
-    // EBPF_OP_MOV64_REG pc=39 dst=r3 src=r6 offset=0 imm=0
-#line 51 "sample/./sample_common_routines.h"
-    r3 = r6;
-    // EBPF_OP_MOV64_IMM pc=40 dst=r4 src=r0 offset=0 imm=0
-#line 51 "sample/./sample_common_routines.h"
-    r4 = IMMEDIATE(0);
-    // EBPF_OP_CALL pc=41 dst=r0 src=r0 offset=0 imm=2
-#line 51 "sample/./sample_common_routines.h"
+    // EBPF_OP_CALL pc=18 dst=r0 src=r0 offset=0 imm=30
+#line 36 "sample/./sample_common_routines.h"
     r0 = test_utility_helpers_helpers[5].address(r1, r2, r3, r4, r5, context);
-#line 51 "sample/./sample_common_routines.h"
+#line 36 "sample/./sample_common_routines.h"
     if ((test_utility_helpers_helpers[5].tail_call) && (r0 == 0)) {
+#line 36 "sample/./sample_common_routines.h"
+        return 0;
+#line 36 "sample/./sample_common_routines.h"
+    }
+    // EBPF_OP_STXDW pc=19 dst=r10 src=r0 offset=-24 imm=0
+#line 36 "sample/./sample_common_routines.h"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-24)) = (uint64_t)r0;
+    // EBPF_OP_CALL pc=20 dst=r0 src=r0 offset=0 imm=31
+#line 39 "sample/./sample_common_routines.h"
+    r0 = test_utility_helpers_helpers[6].address(r1, r2, r3, r4, r5, context);
+#line 39 "sample/./sample_common_routines.h"
+    if ((test_utility_helpers_helpers[6].tail_call) && (r0 == 0)) {
+#line 39 "sample/./sample_common_routines.h"
+        return 0;
+#line 39 "sample/./sample_common_routines.h"
+    }
+    // EBPF_OP_STXDW pc=21 dst=r10 src=r0 offset=-16 imm=0
+#line 39 "sample/./sample_common_routines.h"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint64_t)r0;
+    // EBPF_OP_MOV64_REG pc=22 dst=r2 src=r10 offset=0 imm=0
+#line 39 "sample/./sample_common_routines.h"
+    r2 = r10;
+    // EBPF_OP_ADD64_IMM pc=23 dst=r2 src=r0 offset=0 imm=-8
+#line 39 "sample/./sample_common_routines.h"
+    r2 += IMMEDIATE(-8);
+    // EBPF_OP_MOV64_REG pc=24 dst=r6 src=r10 offset=0 imm=0
+#line 39 "sample/./sample_common_routines.h"
+    r6 = r10;
+    // EBPF_OP_ADD64_IMM pc=25 dst=r6 src=r0 offset=0 imm=-64
+#line 39 "sample/./sample_common_routines.h"
+    r6 += IMMEDIATE(-64);
+    // EBPF_OP_LDDW pc=26 dst=r1 src=r1 offset=0 imm=1
+#line 42 "sample/./sample_common_routines.h"
+    r1 = POINTER(_maps[0].address);
+    // EBPF_OP_MOV64_REG pc=28 dst=r3 src=r6 offset=0 imm=0
+#line 42 "sample/./sample_common_routines.h"
+    r3 = r6;
+    // EBPF_OP_MOV64_IMM pc=29 dst=r4 src=r0 offset=0 imm=0
+#line 42 "sample/./sample_common_routines.h"
+    r4 = IMMEDIATE(0);
+    // EBPF_OP_CALL pc=30 dst=r0 src=r0 offset=0 imm=2
+#line 42 "sample/./sample_common_routines.h"
+    r0 = test_utility_helpers_helpers[7].address(r1, r2, r3, r4, r5, context);
+#line 42 "sample/./sample_common_routines.h"
+    if ((test_utility_helpers_helpers[7].tail_call) && (r0 == 0)) {
+#line 42 "sample/./sample_common_routines.h"
+        return 0;
+#line 42 "sample/./sample_common_routines.h"
+    }
+    // EBPF_OP_CALL pc=31 dst=r0 src=r0 offset=0 imm=6
+#line 45 "sample/./sample_common_routines.h"
+    r0 = test_utility_helpers_helpers[0].address(r1, r2, r3, r4, r5, context);
+#line 45 "sample/./sample_common_routines.h"
+    if ((test_utility_helpers_helpers[0].tail_call) && (r0 == 0)) {
+#line 45 "sample/./sample_common_routines.h"
+        return 0;
+#line 45 "sample/./sample_common_routines.h"
+    }
+    // EBPF_OP_STXW pc=32 dst=r10 src=r0 offset=-64 imm=0
+#line 45 "sample/./sample_common_routines.h"
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-64)) = (uint32_t)r0;
+    // EBPF_OP_CALL pc=33 dst=r0 src=r0 offset=0 imm=9
+#line 48 "sample/./sample_common_routines.h"
+    r0 = test_utility_helpers_helpers[2].address(r1, r2, r3, r4, r5, context);
+#line 48 "sample/./sample_common_routines.h"
+    if ((test_utility_helpers_helpers[2].tail_call) && (r0 == 0)) {
+#line 48 "sample/./sample_common_routines.h"
+        return 0;
+#line 48 "sample/./sample_common_routines.h"
+    }
+    // EBPF_OP_STXDW pc=34 dst=r10 src=r0 offset=-56 imm=0
+#line 48 "sample/./sample_common_routines.h"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-56)) = (uint64_t)r0;
+    // EBPF_OP_CALL pc=35 dst=r0 src=r0 offset=0 imm=7
+#line 51 "sample/./sample_common_routines.h"
+    r0 = test_utility_helpers_helpers[1].address(r1, r2, r3, r4, r5, context);
+#line 51 "sample/./sample_common_routines.h"
+    if ((test_utility_helpers_helpers[1].tail_call) && (r0 == 0)) {
 #line 51 "sample/./sample_common_routines.h"
         return 0;
 #line 51 "sample/./sample_common_routines.h"
     }
-    // EBPF_OP_MOV64_IMM pc=42 dst=r0 src=r0 offset=0 imm=0
+    // EBPF_OP_STXDW pc=36 dst=r10 src=r0 offset=-48 imm=0
+#line 51 "sample/./sample_common_routines.h"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-48)) = (uint64_t)r0;
+    // EBPF_OP_CALL pc=37 dst=r0 src=r0 offset=0 imm=19
+#line 54 "sample/./sample_common_routines.h"
+    r0 = test_utility_helpers_helpers[4].address(r1, r2, r3, r4, r5, context);
+#line 54 "sample/./sample_common_routines.h"
+    if ((test_utility_helpers_helpers[4].tail_call) && (r0 == 0)) {
+#line 54 "sample/./sample_common_routines.h"
+        return 0;
+#line 54 "sample/./sample_common_routines.h"
+    }
+    // EBPF_OP_STXDW pc=38 dst=r10 src=r0 offset=-32 imm=0
+#line 54 "sample/./sample_common_routines.h"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-32)) = (uint64_t)r0;
+    // EBPF_OP_CALL pc=39 dst=r0 src=r0 offset=0 imm=30
+#line 57 "sample/./sample_common_routines.h"
+    r0 = test_utility_helpers_helpers[5].address(r1, r2, r3, r4, r5, context);
+#line 57 "sample/./sample_common_routines.h"
+    if ((test_utility_helpers_helpers[5].tail_call) && (r0 == 0)) {
+#line 57 "sample/./sample_common_routines.h"
+        return 0;
+#line 57 "sample/./sample_common_routines.h"
+    }
+    // EBPF_OP_STXDW pc=40 dst=r10 src=r0 offset=-24 imm=0
+#line 57 "sample/./sample_common_routines.h"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-24)) = (uint64_t)r0;
+    // EBPF_OP_CALL pc=41 dst=r0 src=r0 offset=0 imm=31
+#line 60 "sample/./sample_common_routines.h"
+    r0 = test_utility_helpers_helpers[6].address(r1, r2, r3, r4, r5, context);
+#line 60 "sample/./sample_common_routines.h"
+    if ((test_utility_helpers_helpers[6].tail_call) && (r0 == 0)) {
+#line 60 "sample/./sample_common_routines.h"
+        return 0;
+#line 60 "sample/./sample_common_routines.h"
+    }
+    // EBPF_OP_STXDW pc=42 dst=r10 src=r0 offset=-16 imm=0
+#line 60 "sample/./sample_common_routines.h"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint64_t)r0;
+    // EBPF_OP_MOV64_REG pc=43 dst=r2 src=r10 offset=0 imm=0
+#line 63 "sample/./sample_common_routines.h"
+    r2 = r10;
+    // EBPF_OP_ADD64_IMM pc=44 dst=r2 src=r0 offset=0 imm=-4
+#line 63 "sample/./sample_common_routines.h"
+    r2 += IMMEDIATE(-4);
+    // EBPF_OP_LDDW pc=45 dst=r1 src=r1 offset=0 imm=1
+#line 63 "sample/./sample_common_routines.h"
+    r1 = POINTER(_maps[0].address);
+    // EBPF_OP_MOV64_REG pc=47 dst=r3 src=r6 offset=0 imm=0
+#line 63 "sample/./sample_common_routines.h"
+    r3 = r6;
+    // EBPF_OP_MOV64_IMM pc=48 dst=r4 src=r0 offset=0 imm=0
+#line 63 "sample/./sample_common_routines.h"
+    r4 = IMMEDIATE(0);
+    // EBPF_OP_CALL pc=49 dst=r0 src=r0 offset=0 imm=2
+#line 63 "sample/./sample_common_routines.h"
+    r0 = test_utility_helpers_helpers[7].address(r1, r2, r3, r4, r5, context);
+#line 63 "sample/./sample_common_routines.h"
+    if ((test_utility_helpers_helpers[7].tail_call) && (r0 == 0)) {
+#line 63 "sample/./sample_common_routines.h"
+        return 0;
+#line 63 "sample/./sample_common_routines.h"
+    }
+    // EBPF_OP_MOV64_IMM pc=50 dst=r0 src=r0 offset=0 imm=0
 #line 35 "sample/undocked/test_utility_helpers.c"
     r0 = IMMEDIATE(0);
-    // EBPF_OP_EXIT pc=43 dst=r0 src=r0 offset=0 imm=0
+    // EBPF_OP_EXIT pc=51 dst=r0 src=r0 offset=0 imm=0
 #line 35 "sample/undocked/test_utility_helpers.c"
     return r0;
 #line 33 "sample/undocked/test_utility_helpers.c"
@@ -316,8 +366,8 @@ static program_entry_t _programs[] = {
         test_utility_helpers_maps,
         1,
         test_utility_helpers_helpers,
-        6,
-        44,
+        8,
+        52,
         &test_utility_helpers_program_type_guid,
         &test_utility_helpers_attach_type_guid,
     },

--- a/tests/bpf2c_tests/expected/test_utility_helpers_raw.c
+++ b/tests/bpf2c_tests/expected/test_utility_helpers_raw.c
@@ -19,7 +19,7 @@ static map_entry_t _maps[] = {
      {
          BPF_MAP_TYPE_ARRAY, // Type of map.
          4,                  // Size in bytes of a map key.
-         40,                 // Size in bytes of a map value.
+         56,                 // Size in bytes of a map value.
          2,                  // Maximum number of entries allowed in the map.
          0,                  // Inner map index.
          LIBBPF_PIN_NONE,    // Pinning type for the map.
@@ -43,6 +43,8 @@ static helper_function_entry_t test_utility_helpers_helpers[] = {
     {NULL, 9, "helper_id_9"},
     {NULL, 8, "helper_id_8"},
     {NULL, 19, "helper_id_19"},
+    {NULL, 30, "helper_id_30"},
+    {NULL, 31, "helper_id_31"},
     {NULL, 2, "helper_id_2"},
 };
 
@@ -94,18 +96,18 @@ test_utility_helpers(void* context)
     // EBPF_OP_MOV64_IMM pc=3 dst=r1 src=r0 offset=0 imm=0
 #line 12 "sample/./sample_common_routines.h"
     r1 = IMMEDIATE(0);
-    // EBPF_OP_STXDW pc=4 dst=r10 src=r1 offset=-24 imm=0
-#line 13 "sample/./sample_common_routines.h"
-    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-24)) = (uint64_t)r1;
-    // EBPF_OP_STXDW pc=5 dst=r10 src=r1 offset=-32 imm=0
-#line 13 "sample/./sample_common_routines.h"
-    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-32)) = (uint64_t)r1;
-    // EBPF_OP_STXDW pc=6 dst=r10 src=r1 offset=-40 imm=0
+    // EBPF_OP_STXDW pc=4 dst=r10 src=r1 offset=-40 imm=0
 #line 13 "sample/./sample_common_routines.h"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-40)) = (uint64_t)r1;
-    // EBPF_OP_STXDW pc=7 dst=r10 src=r1 offset=-48 imm=0
+    // EBPF_OP_STXDW pc=5 dst=r10 src=r1 offset=-48 imm=0
 #line 13 "sample/./sample_common_routines.h"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-48)) = (uint64_t)r1;
+    // EBPF_OP_STXDW pc=6 dst=r10 src=r1 offset=-56 imm=0
+#line 13 "sample/./sample_common_routines.h"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-56)) = (uint64_t)r1;
+    // EBPF_OP_STXDW pc=7 dst=r10 src=r1 offset=-64 imm=0
+#line 13 "sample/./sample_common_routines.h"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-64)) = (uint64_t)r1;
     // EBPF_OP_CALL pc=8 dst=r0 src=r0 offset=0 imm=6
 #line 16 "sample/./sample_common_routines.h"
     r0 = test_utility_helpers_helpers[0].address(r1, r2, r3, r4, r5, context);
@@ -115,9 +117,9 @@ test_utility_helpers(void* context)
         return 0;
 #line 16 "sample/./sample_common_routines.h"
     }
-    // EBPF_OP_STXW pc=9 dst=r10 src=r0 offset=-48 imm=0
+    // EBPF_OP_STXW pc=9 dst=r10 src=r0 offset=-64 imm=0
 #line 16 "sample/./sample_common_routines.h"
-    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-48)) = (uint32_t)r0;
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-64)) = (uint32_t)r0;
     // EBPF_OP_CALL pc=10 dst=r0 src=r0 offset=0 imm=7
 #line 24 "sample/./sample_common_routines.h"
     r0 = test_utility_helpers_helpers[1].address(r1, r2, r3, r4, r5, context);
@@ -127,9 +129,9 @@ test_utility_helpers(void* context)
         return 0;
 #line 24 "sample/./sample_common_routines.h"
     }
-    // EBPF_OP_STXDW pc=11 dst=r10 src=r0 offset=-32 imm=0
+    // EBPF_OP_STXDW pc=11 dst=r10 src=r0 offset=-48 imm=0
 #line 24 "sample/./sample_common_routines.h"
-    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-32)) = (uint64_t)r0;
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-48)) = (uint64_t)r0;
     // EBPF_OP_CALL pc=12 dst=r0 src=r0 offset=0 imm=9
 #line 27 "sample/./sample_common_routines.h"
     r0 = test_utility_helpers_helpers[2].address(r1, r2, r3, r4, r5, context);
@@ -139,9 +141,9 @@ test_utility_helpers(void* context)
         return 0;
 #line 27 "sample/./sample_common_routines.h"
     }
-    // EBPF_OP_STXDW pc=13 dst=r10 src=r0 offset=-40 imm=0
+    // EBPF_OP_STXDW pc=13 dst=r10 src=r0 offset=-56 imm=0
 #line 27 "sample/./sample_common_routines.h"
-    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-40)) = (uint64_t)r0;
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-56)) = (uint64_t)r0;
     // EBPF_OP_CALL pc=14 dst=r0 src=r0 offset=0 imm=8
 #line 30 "sample/./sample_common_routines.h"
     r0 = test_utility_helpers_helpers[3].address(r1, r2, r3, r4, r5, context);
@@ -151,9 +153,9 @@ test_utility_helpers(void* context)
         return 0;
 #line 30 "sample/./sample_common_routines.h"
     }
-    // EBPF_OP_STXW pc=15 dst=r10 src=r0 offset=-24 imm=0
+    // EBPF_OP_STXW pc=15 dst=r10 src=r0 offset=-40 imm=0
 #line 30 "sample/./sample_common_routines.h"
-    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-24)) = (uint32_t)r0;
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-40)) = (uint32_t)r0;
     // EBPF_OP_CALL pc=16 dst=r0 src=r0 offset=0 imm=19
 #line 33 "sample/./sample_common_routines.h"
     r0 = test_utility_helpers_helpers[4].address(r1, r2, r3, r4, r5, context);
@@ -163,115 +165,163 @@ test_utility_helpers(void* context)
         return 0;
 #line 33 "sample/./sample_common_routines.h"
     }
-    // EBPF_OP_STXDW pc=17 dst=r10 src=r0 offset=-16 imm=0
+    // EBPF_OP_STXDW pc=17 dst=r10 src=r0 offset=-32 imm=0
 #line 33 "sample/./sample_common_routines.h"
-    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint64_t)r0;
-    // EBPF_OP_MOV64_REG pc=18 dst=r2 src=r10 offset=0 imm=0
-#line 33 "sample/./sample_common_routines.h"
-    r2 = r10;
-    // EBPF_OP_ADD64_IMM pc=19 dst=r2 src=r0 offset=0 imm=-8
-#line 33 "sample/./sample_common_routines.h"
-    r2 += IMMEDIATE(-8);
-    // EBPF_OP_MOV64_REG pc=20 dst=r6 src=r10 offset=0 imm=0
-#line 33 "sample/./sample_common_routines.h"
-    r6 = r10;
-    // EBPF_OP_ADD64_IMM pc=21 dst=r6 src=r0 offset=0 imm=-48
-#line 33 "sample/./sample_common_routines.h"
-    r6 += IMMEDIATE(-48);
-    // EBPF_OP_LDDW pc=22 dst=r1 src=r1 offset=0 imm=1
-#line 36 "sample/./sample_common_routines.h"
-    r1 = POINTER(_maps[0].address);
-    // EBPF_OP_MOV64_REG pc=24 dst=r3 src=r6 offset=0 imm=0
-#line 36 "sample/./sample_common_routines.h"
-    r3 = r6;
-    // EBPF_OP_MOV64_IMM pc=25 dst=r4 src=r0 offset=0 imm=0
-#line 36 "sample/./sample_common_routines.h"
-    r4 = IMMEDIATE(0);
-    // EBPF_OP_CALL pc=26 dst=r0 src=r0 offset=0 imm=2
-#line 36 "sample/./sample_common_routines.h"
-    r0 = test_utility_helpers_helpers[5].address(r1, r2, r3, r4, r5, context);
-#line 36 "sample/./sample_common_routines.h"
-    if ((test_utility_helpers_helpers[5].tail_call) && (r0 == 0)) {
-#line 36 "sample/./sample_common_routines.h"
-        return 0;
-#line 36 "sample/./sample_common_routines.h"
-    }
-    // EBPF_OP_CALL pc=27 dst=r0 src=r0 offset=0 imm=6
-#line 39 "sample/./sample_common_routines.h"
-    r0 = test_utility_helpers_helpers[0].address(r1, r2, r3, r4, r5, context);
-#line 39 "sample/./sample_common_routines.h"
-    if ((test_utility_helpers_helpers[0].tail_call) && (r0 == 0)) {
-#line 39 "sample/./sample_common_routines.h"
-        return 0;
-#line 39 "sample/./sample_common_routines.h"
-    }
-    // EBPF_OP_STXW pc=28 dst=r10 src=r0 offset=-48 imm=0
-#line 39 "sample/./sample_common_routines.h"
-    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-48)) = (uint32_t)r0;
-    // EBPF_OP_CALL pc=29 dst=r0 src=r0 offset=0 imm=9
-#line 42 "sample/./sample_common_routines.h"
-    r0 = test_utility_helpers_helpers[2].address(r1, r2, r3, r4, r5, context);
-#line 42 "sample/./sample_common_routines.h"
-    if ((test_utility_helpers_helpers[2].tail_call) && (r0 == 0)) {
-#line 42 "sample/./sample_common_routines.h"
-        return 0;
-#line 42 "sample/./sample_common_routines.h"
-    }
-    // EBPF_OP_STXDW pc=30 dst=r10 src=r0 offset=-40 imm=0
-#line 42 "sample/./sample_common_routines.h"
-    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-40)) = (uint64_t)r0;
-    // EBPF_OP_CALL pc=31 dst=r0 src=r0 offset=0 imm=7
-#line 45 "sample/./sample_common_routines.h"
-    r0 = test_utility_helpers_helpers[1].address(r1, r2, r3, r4, r5, context);
-#line 45 "sample/./sample_common_routines.h"
-    if ((test_utility_helpers_helpers[1].tail_call) && (r0 == 0)) {
-#line 45 "sample/./sample_common_routines.h"
-        return 0;
-#line 45 "sample/./sample_common_routines.h"
-    }
-    // EBPF_OP_STXDW pc=32 dst=r10 src=r0 offset=-32 imm=0
-#line 45 "sample/./sample_common_routines.h"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-32)) = (uint64_t)r0;
-    // EBPF_OP_CALL pc=33 dst=r0 src=r0 offset=0 imm=19
-#line 48 "sample/./sample_common_routines.h"
-    r0 = test_utility_helpers_helpers[4].address(r1, r2, r3, r4, r5, context);
-#line 48 "sample/./sample_common_routines.h"
-    if ((test_utility_helpers_helpers[4].tail_call) && (r0 == 0)) {
-#line 48 "sample/./sample_common_routines.h"
-        return 0;
-#line 48 "sample/./sample_common_routines.h"
-    }
-    // EBPF_OP_STXDW pc=34 dst=r10 src=r0 offset=-16 imm=0
-#line 48 "sample/./sample_common_routines.h"
-    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint64_t)r0;
-    // EBPF_OP_MOV64_REG pc=35 dst=r2 src=r10 offset=0 imm=0
-#line 51 "sample/./sample_common_routines.h"
-    r2 = r10;
-    // EBPF_OP_ADD64_IMM pc=36 dst=r2 src=r0 offset=0 imm=-4
-#line 51 "sample/./sample_common_routines.h"
-    r2 += IMMEDIATE(-4);
-    // EBPF_OP_LDDW pc=37 dst=r1 src=r1 offset=0 imm=1
-#line 51 "sample/./sample_common_routines.h"
-    r1 = POINTER(_maps[0].address);
-    // EBPF_OP_MOV64_REG pc=39 dst=r3 src=r6 offset=0 imm=0
-#line 51 "sample/./sample_common_routines.h"
-    r3 = r6;
-    // EBPF_OP_MOV64_IMM pc=40 dst=r4 src=r0 offset=0 imm=0
-#line 51 "sample/./sample_common_routines.h"
-    r4 = IMMEDIATE(0);
-    // EBPF_OP_CALL pc=41 dst=r0 src=r0 offset=0 imm=2
-#line 51 "sample/./sample_common_routines.h"
+    // EBPF_OP_CALL pc=18 dst=r0 src=r0 offset=0 imm=30
+#line 36 "sample/./sample_common_routines.h"
     r0 = test_utility_helpers_helpers[5].address(r1, r2, r3, r4, r5, context);
-#line 51 "sample/./sample_common_routines.h"
+#line 36 "sample/./sample_common_routines.h"
     if ((test_utility_helpers_helpers[5].tail_call) && (r0 == 0)) {
+#line 36 "sample/./sample_common_routines.h"
+        return 0;
+#line 36 "sample/./sample_common_routines.h"
+    }
+    // EBPF_OP_STXDW pc=19 dst=r10 src=r0 offset=-24 imm=0
+#line 36 "sample/./sample_common_routines.h"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-24)) = (uint64_t)r0;
+    // EBPF_OP_CALL pc=20 dst=r0 src=r0 offset=0 imm=31
+#line 39 "sample/./sample_common_routines.h"
+    r0 = test_utility_helpers_helpers[6].address(r1, r2, r3, r4, r5, context);
+#line 39 "sample/./sample_common_routines.h"
+    if ((test_utility_helpers_helpers[6].tail_call) && (r0 == 0)) {
+#line 39 "sample/./sample_common_routines.h"
+        return 0;
+#line 39 "sample/./sample_common_routines.h"
+    }
+    // EBPF_OP_STXDW pc=21 dst=r10 src=r0 offset=-16 imm=0
+#line 39 "sample/./sample_common_routines.h"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint64_t)r0;
+    // EBPF_OP_MOV64_REG pc=22 dst=r2 src=r10 offset=0 imm=0
+#line 39 "sample/./sample_common_routines.h"
+    r2 = r10;
+    // EBPF_OP_ADD64_IMM pc=23 dst=r2 src=r0 offset=0 imm=-8
+#line 39 "sample/./sample_common_routines.h"
+    r2 += IMMEDIATE(-8);
+    // EBPF_OP_MOV64_REG pc=24 dst=r6 src=r10 offset=0 imm=0
+#line 39 "sample/./sample_common_routines.h"
+    r6 = r10;
+    // EBPF_OP_ADD64_IMM pc=25 dst=r6 src=r0 offset=0 imm=-64
+#line 39 "sample/./sample_common_routines.h"
+    r6 += IMMEDIATE(-64);
+    // EBPF_OP_LDDW pc=26 dst=r1 src=r1 offset=0 imm=1
+#line 42 "sample/./sample_common_routines.h"
+    r1 = POINTER(_maps[0].address);
+    // EBPF_OP_MOV64_REG pc=28 dst=r3 src=r6 offset=0 imm=0
+#line 42 "sample/./sample_common_routines.h"
+    r3 = r6;
+    // EBPF_OP_MOV64_IMM pc=29 dst=r4 src=r0 offset=0 imm=0
+#line 42 "sample/./sample_common_routines.h"
+    r4 = IMMEDIATE(0);
+    // EBPF_OP_CALL pc=30 dst=r0 src=r0 offset=0 imm=2
+#line 42 "sample/./sample_common_routines.h"
+    r0 = test_utility_helpers_helpers[7].address(r1, r2, r3, r4, r5, context);
+#line 42 "sample/./sample_common_routines.h"
+    if ((test_utility_helpers_helpers[7].tail_call) && (r0 == 0)) {
+#line 42 "sample/./sample_common_routines.h"
+        return 0;
+#line 42 "sample/./sample_common_routines.h"
+    }
+    // EBPF_OP_CALL pc=31 dst=r0 src=r0 offset=0 imm=6
+#line 45 "sample/./sample_common_routines.h"
+    r0 = test_utility_helpers_helpers[0].address(r1, r2, r3, r4, r5, context);
+#line 45 "sample/./sample_common_routines.h"
+    if ((test_utility_helpers_helpers[0].tail_call) && (r0 == 0)) {
+#line 45 "sample/./sample_common_routines.h"
+        return 0;
+#line 45 "sample/./sample_common_routines.h"
+    }
+    // EBPF_OP_STXW pc=32 dst=r10 src=r0 offset=-64 imm=0
+#line 45 "sample/./sample_common_routines.h"
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-64)) = (uint32_t)r0;
+    // EBPF_OP_CALL pc=33 dst=r0 src=r0 offset=0 imm=9
+#line 48 "sample/./sample_common_routines.h"
+    r0 = test_utility_helpers_helpers[2].address(r1, r2, r3, r4, r5, context);
+#line 48 "sample/./sample_common_routines.h"
+    if ((test_utility_helpers_helpers[2].tail_call) && (r0 == 0)) {
+#line 48 "sample/./sample_common_routines.h"
+        return 0;
+#line 48 "sample/./sample_common_routines.h"
+    }
+    // EBPF_OP_STXDW pc=34 dst=r10 src=r0 offset=-56 imm=0
+#line 48 "sample/./sample_common_routines.h"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-56)) = (uint64_t)r0;
+    // EBPF_OP_CALL pc=35 dst=r0 src=r0 offset=0 imm=7
+#line 51 "sample/./sample_common_routines.h"
+    r0 = test_utility_helpers_helpers[1].address(r1, r2, r3, r4, r5, context);
+#line 51 "sample/./sample_common_routines.h"
+    if ((test_utility_helpers_helpers[1].tail_call) && (r0 == 0)) {
 #line 51 "sample/./sample_common_routines.h"
         return 0;
 #line 51 "sample/./sample_common_routines.h"
     }
-    // EBPF_OP_MOV64_IMM pc=42 dst=r0 src=r0 offset=0 imm=0
+    // EBPF_OP_STXDW pc=36 dst=r10 src=r0 offset=-48 imm=0
+#line 51 "sample/./sample_common_routines.h"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-48)) = (uint64_t)r0;
+    // EBPF_OP_CALL pc=37 dst=r0 src=r0 offset=0 imm=19
+#line 54 "sample/./sample_common_routines.h"
+    r0 = test_utility_helpers_helpers[4].address(r1, r2, r3, r4, r5, context);
+#line 54 "sample/./sample_common_routines.h"
+    if ((test_utility_helpers_helpers[4].tail_call) && (r0 == 0)) {
+#line 54 "sample/./sample_common_routines.h"
+        return 0;
+#line 54 "sample/./sample_common_routines.h"
+    }
+    // EBPF_OP_STXDW pc=38 dst=r10 src=r0 offset=-32 imm=0
+#line 54 "sample/./sample_common_routines.h"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-32)) = (uint64_t)r0;
+    // EBPF_OP_CALL pc=39 dst=r0 src=r0 offset=0 imm=30
+#line 57 "sample/./sample_common_routines.h"
+    r0 = test_utility_helpers_helpers[5].address(r1, r2, r3, r4, r5, context);
+#line 57 "sample/./sample_common_routines.h"
+    if ((test_utility_helpers_helpers[5].tail_call) && (r0 == 0)) {
+#line 57 "sample/./sample_common_routines.h"
+        return 0;
+#line 57 "sample/./sample_common_routines.h"
+    }
+    // EBPF_OP_STXDW pc=40 dst=r10 src=r0 offset=-24 imm=0
+#line 57 "sample/./sample_common_routines.h"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-24)) = (uint64_t)r0;
+    // EBPF_OP_CALL pc=41 dst=r0 src=r0 offset=0 imm=31
+#line 60 "sample/./sample_common_routines.h"
+    r0 = test_utility_helpers_helpers[6].address(r1, r2, r3, r4, r5, context);
+#line 60 "sample/./sample_common_routines.h"
+    if ((test_utility_helpers_helpers[6].tail_call) && (r0 == 0)) {
+#line 60 "sample/./sample_common_routines.h"
+        return 0;
+#line 60 "sample/./sample_common_routines.h"
+    }
+    // EBPF_OP_STXDW pc=42 dst=r10 src=r0 offset=-16 imm=0
+#line 60 "sample/./sample_common_routines.h"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint64_t)r0;
+    // EBPF_OP_MOV64_REG pc=43 dst=r2 src=r10 offset=0 imm=0
+#line 63 "sample/./sample_common_routines.h"
+    r2 = r10;
+    // EBPF_OP_ADD64_IMM pc=44 dst=r2 src=r0 offset=0 imm=-4
+#line 63 "sample/./sample_common_routines.h"
+    r2 += IMMEDIATE(-4);
+    // EBPF_OP_LDDW pc=45 dst=r1 src=r1 offset=0 imm=1
+#line 63 "sample/./sample_common_routines.h"
+    r1 = POINTER(_maps[0].address);
+    // EBPF_OP_MOV64_REG pc=47 dst=r3 src=r6 offset=0 imm=0
+#line 63 "sample/./sample_common_routines.h"
+    r3 = r6;
+    // EBPF_OP_MOV64_IMM pc=48 dst=r4 src=r0 offset=0 imm=0
+#line 63 "sample/./sample_common_routines.h"
+    r4 = IMMEDIATE(0);
+    // EBPF_OP_CALL pc=49 dst=r0 src=r0 offset=0 imm=2
+#line 63 "sample/./sample_common_routines.h"
+    r0 = test_utility_helpers_helpers[7].address(r1, r2, r3, r4, r5, context);
+#line 63 "sample/./sample_common_routines.h"
+    if ((test_utility_helpers_helpers[7].tail_call) && (r0 == 0)) {
+#line 63 "sample/./sample_common_routines.h"
+        return 0;
+#line 63 "sample/./sample_common_routines.h"
+    }
+    // EBPF_OP_MOV64_IMM pc=50 dst=r0 src=r0 offset=0 imm=0
 #line 35 "sample/undocked/test_utility_helpers.c"
     r0 = IMMEDIATE(0);
-    // EBPF_OP_EXIT pc=43 dst=r0 src=r0 offset=0 imm=0
+    // EBPF_OP_EXIT pc=51 dst=r0 src=r0 offset=0 imm=0
 #line 35 "sample/undocked/test_utility_helpers.c"
     return r0;
 #line 33 "sample/undocked/test_utility_helpers.c"
@@ -290,8 +340,8 @@ static program_entry_t _programs[] = {
         test_utility_helpers_maps,
         1,
         test_utility_helpers_helpers,
-        6,
-        44,
+        8,
+        52,
         &test_utility_helpers_program_type_guid,
         &test_utility_helpers_attach_type_guid,
     },

--- a/tests/bpf2c_tests/expected/test_utility_helpers_sys.c
+++ b/tests/bpf2c_tests/expected/test_utility_helpers_sys.c
@@ -180,7 +180,7 @@ static map_entry_t _maps[] = {
      {
          BPF_MAP_TYPE_ARRAY, // Type of map.
          4,                  // Size in bytes of a map key.
-         40,                 // Size in bytes of a map value.
+         56,                 // Size in bytes of a map value.
          2,                  // Maximum number of entries allowed in the map.
          0,                  // Inner map index.
          LIBBPF_PIN_NONE,    // Pinning type for the map.
@@ -204,6 +204,8 @@ static helper_function_entry_t test_utility_helpers_helpers[] = {
     {NULL, 9, "helper_id_9"},
     {NULL, 8, "helper_id_8"},
     {NULL, 19, "helper_id_19"},
+    {NULL, 30, "helper_id_30"},
+    {NULL, 31, "helper_id_31"},
     {NULL, 2, "helper_id_2"},
 };
 
@@ -255,18 +257,18 @@ test_utility_helpers(void* context)
     // EBPF_OP_MOV64_IMM pc=3 dst=r1 src=r0 offset=0 imm=0
 #line 12 "sample/./sample_common_routines.h"
     r1 = IMMEDIATE(0);
-    // EBPF_OP_STXDW pc=4 dst=r10 src=r1 offset=-24 imm=0
-#line 13 "sample/./sample_common_routines.h"
-    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-24)) = (uint64_t)r1;
-    // EBPF_OP_STXDW pc=5 dst=r10 src=r1 offset=-32 imm=0
-#line 13 "sample/./sample_common_routines.h"
-    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-32)) = (uint64_t)r1;
-    // EBPF_OP_STXDW pc=6 dst=r10 src=r1 offset=-40 imm=0
+    // EBPF_OP_STXDW pc=4 dst=r10 src=r1 offset=-40 imm=0
 #line 13 "sample/./sample_common_routines.h"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-40)) = (uint64_t)r1;
-    // EBPF_OP_STXDW pc=7 dst=r10 src=r1 offset=-48 imm=0
+    // EBPF_OP_STXDW pc=5 dst=r10 src=r1 offset=-48 imm=0
 #line 13 "sample/./sample_common_routines.h"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-48)) = (uint64_t)r1;
+    // EBPF_OP_STXDW pc=6 dst=r10 src=r1 offset=-56 imm=0
+#line 13 "sample/./sample_common_routines.h"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-56)) = (uint64_t)r1;
+    // EBPF_OP_STXDW pc=7 dst=r10 src=r1 offset=-64 imm=0
+#line 13 "sample/./sample_common_routines.h"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-64)) = (uint64_t)r1;
     // EBPF_OP_CALL pc=8 dst=r0 src=r0 offset=0 imm=6
 #line 16 "sample/./sample_common_routines.h"
     r0 = test_utility_helpers_helpers[0].address(r1, r2, r3, r4, r5, context);
@@ -276,9 +278,9 @@ test_utility_helpers(void* context)
         return 0;
 #line 16 "sample/./sample_common_routines.h"
     }
-    // EBPF_OP_STXW pc=9 dst=r10 src=r0 offset=-48 imm=0
+    // EBPF_OP_STXW pc=9 dst=r10 src=r0 offset=-64 imm=0
 #line 16 "sample/./sample_common_routines.h"
-    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-48)) = (uint32_t)r0;
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-64)) = (uint32_t)r0;
     // EBPF_OP_CALL pc=10 dst=r0 src=r0 offset=0 imm=7
 #line 24 "sample/./sample_common_routines.h"
     r0 = test_utility_helpers_helpers[1].address(r1, r2, r3, r4, r5, context);
@@ -288,9 +290,9 @@ test_utility_helpers(void* context)
         return 0;
 #line 24 "sample/./sample_common_routines.h"
     }
-    // EBPF_OP_STXDW pc=11 dst=r10 src=r0 offset=-32 imm=0
+    // EBPF_OP_STXDW pc=11 dst=r10 src=r0 offset=-48 imm=0
 #line 24 "sample/./sample_common_routines.h"
-    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-32)) = (uint64_t)r0;
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-48)) = (uint64_t)r0;
     // EBPF_OP_CALL pc=12 dst=r0 src=r0 offset=0 imm=9
 #line 27 "sample/./sample_common_routines.h"
     r0 = test_utility_helpers_helpers[2].address(r1, r2, r3, r4, r5, context);
@@ -300,9 +302,9 @@ test_utility_helpers(void* context)
         return 0;
 #line 27 "sample/./sample_common_routines.h"
     }
-    // EBPF_OP_STXDW pc=13 dst=r10 src=r0 offset=-40 imm=0
+    // EBPF_OP_STXDW pc=13 dst=r10 src=r0 offset=-56 imm=0
 #line 27 "sample/./sample_common_routines.h"
-    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-40)) = (uint64_t)r0;
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-56)) = (uint64_t)r0;
     // EBPF_OP_CALL pc=14 dst=r0 src=r0 offset=0 imm=8
 #line 30 "sample/./sample_common_routines.h"
     r0 = test_utility_helpers_helpers[3].address(r1, r2, r3, r4, r5, context);
@@ -312,9 +314,9 @@ test_utility_helpers(void* context)
         return 0;
 #line 30 "sample/./sample_common_routines.h"
     }
-    // EBPF_OP_STXW pc=15 dst=r10 src=r0 offset=-24 imm=0
+    // EBPF_OP_STXW pc=15 dst=r10 src=r0 offset=-40 imm=0
 #line 30 "sample/./sample_common_routines.h"
-    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-24)) = (uint32_t)r0;
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-40)) = (uint32_t)r0;
     // EBPF_OP_CALL pc=16 dst=r0 src=r0 offset=0 imm=19
 #line 33 "sample/./sample_common_routines.h"
     r0 = test_utility_helpers_helpers[4].address(r1, r2, r3, r4, r5, context);
@@ -324,115 +326,163 @@ test_utility_helpers(void* context)
         return 0;
 #line 33 "sample/./sample_common_routines.h"
     }
-    // EBPF_OP_STXDW pc=17 dst=r10 src=r0 offset=-16 imm=0
+    // EBPF_OP_STXDW pc=17 dst=r10 src=r0 offset=-32 imm=0
 #line 33 "sample/./sample_common_routines.h"
-    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint64_t)r0;
-    // EBPF_OP_MOV64_REG pc=18 dst=r2 src=r10 offset=0 imm=0
-#line 33 "sample/./sample_common_routines.h"
-    r2 = r10;
-    // EBPF_OP_ADD64_IMM pc=19 dst=r2 src=r0 offset=0 imm=-8
-#line 33 "sample/./sample_common_routines.h"
-    r2 += IMMEDIATE(-8);
-    // EBPF_OP_MOV64_REG pc=20 dst=r6 src=r10 offset=0 imm=0
-#line 33 "sample/./sample_common_routines.h"
-    r6 = r10;
-    // EBPF_OP_ADD64_IMM pc=21 dst=r6 src=r0 offset=0 imm=-48
-#line 33 "sample/./sample_common_routines.h"
-    r6 += IMMEDIATE(-48);
-    // EBPF_OP_LDDW pc=22 dst=r1 src=r1 offset=0 imm=1
-#line 36 "sample/./sample_common_routines.h"
-    r1 = POINTER(_maps[0].address);
-    // EBPF_OP_MOV64_REG pc=24 dst=r3 src=r6 offset=0 imm=0
-#line 36 "sample/./sample_common_routines.h"
-    r3 = r6;
-    // EBPF_OP_MOV64_IMM pc=25 dst=r4 src=r0 offset=0 imm=0
-#line 36 "sample/./sample_common_routines.h"
-    r4 = IMMEDIATE(0);
-    // EBPF_OP_CALL pc=26 dst=r0 src=r0 offset=0 imm=2
-#line 36 "sample/./sample_common_routines.h"
-    r0 = test_utility_helpers_helpers[5].address(r1, r2, r3, r4, r5, context);
-#line 36 "sample/./sample_common_routines.h"
-    if ((test_utility_helpers_helpers[5].tail_call) && (r0 == 0)) {
-#line 36 "sample/./sample_common_routines.h"
-        return 0;
-#line 36 "sample/./sample_common_routines.h"
-    }
-    // EBPF_OP_CALL pc=27 dst=r0 src=r0 offset=0 imm=6
-#line 39 "sample/./sample_common_routines.h"
-    r0 = test_utility_helpers_helpers[0].address(r1, r2, r3, r4, r5, context);
-#line 39 "sample/./sample_common_routines.h"
-    if ((test_utility_helpers_helpers[0].tail_call) && (r0 == 0)) {
-#line 39 "sample/./sample_common_routines.h"
-        return 0;
-#line 39 "sample/./sample_common_routines.h"
-    }
-    // EBPF_OP_STXW pc=28 dst=r10 src=r0 offset=-48 imm=0
-#line 39 "sample/./sample_common_routines.h"
-    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-48)) = (uint32_t)r0;
-    // EBPF_OP_CALL pc=29 dst=r0 src=r0 offset=0 imm=9
-#line 42 "sample/./sample_common_routines.h"
-    r0 = test_utility_helpers_helpers[2].address(r1, r2, r3, r4, r5, context);
-#line 42 "sample/./sample_common_routines.h"
-    if ((test_utility_helpers_helpers[2].tail_call) && (r0 == 0)) {
-#line 42 "sample/./sample_common_routines.h"
-        return 0;
-#line 42 "sample/./sample_common_routines.h"
-    }
-    // EBPF_OP_STXDW pc=30 dst=r10 src=r0 offset=-40 imm=0
-#line 42 "sample/./sample_common_routines.h"
-    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-40)) = (uint64_t)r0;
-    // EBPF_OP_CALL pc=31 dst=r0 src=r0 offset=0 imm=7
-#line 45 "sample/./sample_common_routines.h"
-    r0 = test_utility_helpers_helpers[1].address(r1, r2, r3, r4, r5, context);
-#line 45 "sample/./sample_common_routines.h"
-    if ((test_utility_helpers_helpers[1].tail_call) && (r0 == 0)) {
-#line 45 "sample/./sample_common_routines.h"
-        return 0;
-#line 45 "sample/./sample_common_routines.h"
-    }
-    // EBPF_OP_STXDW pc=32 dst=r10 src=r0 offset=-32 imm=0
-#line 45 "sample/./sample_common_routines.h"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-32)) = (uint64_t)r0;
-    // EBPF_OP_CALL pc=33 dst=r0 src=r0 offset=0 imm=19
-#line 48 "sample/./sample_common_routines.h"
-    r0 = test_utility_helpers_helpers[4].address(r1, r2, r3, r4, r5, context);
-#line 48 "sample/./sample_common_routines.h"
-    if ((test_utility_helpers_helpers[4].tail_call) && (r0 == 0)) {
-#line 48 "sample/./sample_common_routines.h"
-        return 0;
-#line 48 "sample/./sample_common_routines.h"
-    }
-    // EBPF_OP_STXDW pc=34 dst=r10 src=r0 offset=-16 imm=0
-#line 48 "sample/./sample_common_routines.h"
-    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint64_t)r0;
-    // EBPF_OP_MOV64_REG pc=35 dst=r2 src=r10 offset=0 imm=0
-#line 51 "sample/./sample_common_routines.h"
-    r2 = r10;
-    // EBPF_OP_ADD64_IMM pc=36 dst=r2 src=r0 offset=0 imm=-4
-#line 51 "sample/./sample_common_routines.h"
-    r2 += IMMEDIATE(-4);
-    // EBPF_OP_LDDW pc=37 dst=r1 src=r1 offset=0 imm=1
-#line 51 "sample/./sample_common_routines.h"
-    r1 = POINTER(_maps[0].address);
-    // EBPF_OP_MOV64_REG pc=39 dst=r3 src=r6 offset=0 imm=0
-#line 51 "sample/./sample_common_routines.h"
-    r3 = r6;
-    // EBPF_OP_MOV64_IMM pc=40 dst=r4 src=r0 offset=0 imm=0
-#line 51 "sample/./sample_common_routines.h"
-    r4 = IMMEDIATE(0);
-    // EBPF_OP_CALL pc=41 dst=r0 src=r0 offset=0 imm=2
-#line 51 "sample/./sample_common_routines.h"
+    // EBPF_OP_CALL pc=18 dst=r0 src=r0 offset=0 imm=30
+#line 36 "sample/./sample_common_routines.h"
     r0 = test_utility_helpers_helpers[5].address(r1, r2, r3, r4, r5, context);
-#line 51 "sample/./sample_common_routines.h"
+#line 36 "sample/./sample_common_routines.h"
     if ((test_utility_helpers_helpers[5].tail_call) && (r0 == 0)) {
+#line 36 "sample/./sample_common_routines.h"
+        return 0;
+#line 36 "sample/./sample_common_routines.h"
+    }
+    // EBPF_OP_STXDW pc=19 dst=r10 src=r0 offset=-24 imm=0
+#line 36 "sample/./sample_common_routines.h"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-24)) = (uint64_t)r0;
+    // EBPF_OP_CALL pc=20 dst=r0 src=r0 offset=0 imm=31
+#line 39 "sample/./sample_common_routines.h"
+    r0 = test_utility_helpers_helpers[6].address(r1, r2, r3, r4, r5, context);
+#line 39 "sample/./sample_common_routines.h"
+    if ((test_utility_helpers_helpers[6].tail_call) && (r0 == 0)) {
+#line 39 "sample/./sample_common_routines.h"
+        return 0;
+#line 39 "sample/./sample_common_routines.h"
+    }
+    // EBPF_OP_STXDW pc=21 dst=r10 src=r0 offset=-16 imm=0
+#line 39 "sample/./sample_common_routines.h"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint64_t)r0;
+    // EBPF_OP_MOV64_REG pc=22 dst=r2 src=r10 offset=0 imm=0
+#line 39 "sample/./sample_common_routines.h"
+    r2 = r10;
+    // EBPF_OP_ADD64_IMM pc=23 dst=r2 src=r0 offset=0 imm=-8
+#line 39 "sample/./sample_common_routines.h"
+    r2 += IMMEDIATE(-8);
+    // EBPF_OP_MOV64_REG pc=24 dst=r6 src=r10 offset=0 imm=0
+#line 39 "sample/./sample_common_routines.h"
+    r6 = r10;
+    // EBPF_OP_ADD64_IMM pc=25 dst=r6 src=r0 offset=0 imm=-64
+#line 39 "sample/./sample_common_routines.h"
+    r6 += IMMEDIATE(-64);
+    // EBPF_OP_LDDW pc=26 dst=r1 src=r1 offset=0 imm=1
+#line 42 "sample/./sample_common_routines.h"
+    r1 = POINTER(_maps[0].address);
+    // EBPF_OP_MOV64_REG pc=28 dst=r3 src=r6 offset=0 imm=0
+#line 42 "sample/./sample_common_routines.h"
+    r3 = r6;
+    // EBPF_OP_MOV64_IMM pc=29 dst=r4 src=r0 offset=0 imm=0
+#line 42 "sample/./sample_common_routines.h"
+    r4 = IMMEDIATE(0);
+    // EBPF_OP_CALL pc=30 dst=r0 src=r0 offset=0 imm=2
+#line 42 "sample/./sample_common_routines.h"
+    r0 = test_utility_helpers_helpers[7].address(r1, r2, r3, r4, r5, context);
+#line 42 "sample/./sample_common_routines.h"
+    if ((test_utility_helpers_helpers[7].tail_call) && (r0 == 0)) {
+#line 42 "sample/./sample_common_routines.h"
+        return 0;
+#line 42 "sample/./sample_common_routines.h"
+    }
+    // EBPF_OP_CALL pc=31 dst=r0 src=r0 offset=0 imm=6
+#line 45 "sample/./sample_common_routines.h"
+    r0 = test_utility_helpers_helpers[0].address(r1, r2, r3, r4, r5, context);
+#line 45 "sample/./sample_common_routines.h"
+    if ((test_utility_helpers_helpers[0].tail_call) && (r0 == 0)) {
+#line 45 "sample/./sample_common_routines.h"
+        return 0;
+#line 45 "sample/./sample_common_routines.h"
+    }
+    // EBPF_OP_STXW pc=32 dst=r10 src=r0 offset=-64 imm=0
+#line 45 "sample/./sample_common_routines.h"
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-64)) = (uint32_t)r0;
+    // EBPF_OP_CALL pc=33 dst=r0 src=r0 offset=0 imm=9
+#line 48 "sample/./sample_common_routines.h"
+    r0 = test_utility_helpers_helpers[2].address(r1, r2, r3, r4, r5, context);
+#line 48 "sample/./sample_common_routines.h"
+    if ((test_utility_helpers_helpers[2].tail_call) && (r0 == 0)) {
+#line 48 "sample/./sample_common_routines.h"
+        return 0;
+#line 48 "sample/./sample_common_routines.h"
+    }
+    // EBPF_OP_STXDW pc=34 dst=r10 src=r0 offset=-56 imm=0
+#line 48 "sample/./sample_common_routines.h"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-56)) = (uint64_t)r0;
+    // EBPF_OP_CALL pc=35 dst=r0 src=r0 offset=0 imm=7
+#line 51 "sample/./sample_common_routines.h"
+    r0 = test_utility_helpers_helpers[1].address(r1, r2, r3, r4, r5, context);
+#line 51 "sample/./sample_common_routines.h"
+    if ((test_utility_helpers_helpers[1].tail_call) && (r0 == 0)) {
 #line 51 "sample/./sample_common_routines.h"
         return 0;
 #line 51 "sample/./sample_common_routines.h"
     }
-    // EBPF_OP_MOV64_IMM pc=42 dst=r0 src=r0 offset=0 imm=0
+    // EBPF_OP_STXDW pc=36 dst=r10 src=r0 offset=-48 imm=0
+#line 51 "sample/./sample_common_routines.h"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-48)) = (uint64_t)r0;
+    // EBPF_OP_CALL pc=37 dst=r0 src=r0 offset=0 imm=19
+#line 54 "sample/./sample_common_routines.h"
+    r0 = test_utility_helpers_helpers[4].address(r1, r2, r3, r4, r5, context);
+#line 54 "sample/./sample_common_routines.h"
+    if ((test_utility_helpers_helpers[4].tail_call) && (r0 == 0)) {
+#line 54 "sample/./sample_common_routines.h"
+        return 0;
+#line 54 "sample/./sample_common_routines.h"
+    }
+    // EBPF_OP_STXDW pc=38 dst=r10 src=r0 offset=-32 imm=0
+#line 54 "sample/./sample_common_routines.h"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-32)) = (uint64_t)r0;
+    // EBPF_OP_CALL pc=39 dst=r0 src=r0 offset=0 imm=30
+#line 57 "sample/./sample_common_routines.h"
+    r0 = test_utility_helpers_helpers[5].address(r1, r2, r3, r4, r5, context);
+#line 57 "sample/./sample_common_routines.h"
+    if ((test_utility_helpers_helpers[5].tail_call) && (r0 == 0)) {
+#line 57 "sample/./sample_common_routines.h"
+        return 0;
+#line 57 "sample/./sample_common_routines.h"
+    }
+    // EBPF_OP_STXDW pc=40 dst=r10 src=r0 offset=-24 imm=0
+#line 57 "sample/./sample_common_routines.h"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-24)) = (uint64_t)r0;
+    // EBPF_OP_CALL pc=41 dst=r0 src=r0 offset=0 imm=31
+#line 60 "sample/./sample_common_routines.h"
+    r0 = test_utility_helpers_helpers[6].address(r1, r2, r3, r4, r5, context);
+#line 60 "sample/./sample_common_routines.h"
+    if ((test_utility_helpers_helpers[6].tail_call) && (r0 == 0)) {
+#line 60 "sample/./sample_common_routines.h"
+        return 0;
+#line 60 "sample/./sample_common_routines.h"
+    }
+    // EBPF_OP_STXDW pc=42 dst=r10 src=r0 offset=-16 imm=0
+#line 60 "sample/./sample_common_routines.h"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint64_t)r0;
+    // EBPF_OP_MOV64_REG pc=43 dst=r2 src=r10 offset=0 imm=0
+#line 63 "sample/./sample_common_routines.h"
+    r2 = r10;
+    // EBPF_OP_ADD64_IMM pc=44 dst=r2 src=r0 offset=0 imm=-4
+#line 63 "sample/./sample_common_routines.h"
+    r2 += IMMEDIATE(-4);
+    // EBPF_OP_LDDW pc=45 dst=r1 src=r1 offset=0 imm=1
+#line 63 "sample/./sample_common_routines.h"
+    r1 = POINTER(_maps[0].address);
+    // EBPF_OP_MOV64_REG pc=47 dst=r3 src=r6 offset=0 imm=0
+#line 63 "sample/./sample_common_routines.h"
+    r3 = r6;
+    // EBPF_OP_MOV64_IMM pc=48 dst=r4 src=r0 offset=0 imm=0
+#line 63 "sample/./sample_common_routines.h"
+    r4 = IMMEDIATE(0);
+    // EBPF_OP_CALL pc=49 dst=r0 src=r0 offset=0 imm=2
+#line 63 "sample/./sample_common_routines.h"
+    r0 = test_utility_helpers_helpers[7].address(r1, r2, r3, r4, r5, context);
+#line 63 "sample/./sample_common_routines.h"
+    if ((test_utility_helpers_helpers[7].tail_call) && (r0 == 0)) {
+#line 63 "sample/./sample_common_routines.h"
+        return 0;
+#line 63 "sample/./sample_common_routines.h"
+    }
+    // EBPF_OP_MOV64_IMM pc=50 dst=r0 src=r0 offset=0 imm=0
 #line 35 "sample/undocked/test_utility_helpers.c"
     r0 = IMMEDIATE(0);
-    // EBPF_OP_EXIT pc=43 dst=r0 src=r0 offset=0 imm=0
+    // EBPF_OP_EXIT pc=51 dst=r0 src=r0 offset=0 imm=0
 #line 35 "sample/undocked/test_utility_helpers.c"
     return r0;
 #line 33 "sample/undocked/test_utility_helpers.c"
@@ -451,8 +501,8 @@ static program_entry_t _programs[] = {
         test_utility_helpers_maps,
         1,
         test_utility_helpers_helpers,
-        6,
-        44,
+        8,
+        52,
         &test_utility_helpers_program_type_guid,
         &test_utility_helpers_attach_type_guid,
     },

--- a/tests/libs/common/common_tests.cpp
+++ b/tests/libs/common/common_tests.cpp
@@ -94,8 +94,10 @@ verify_utility_helper_results(_In_ const bpf_object* object, bool helper_overrid
     }
 
     REQUIRE(test_data[0].random != test_data[1].random);
-    REQUIRE(test_data[0].timestamp < test_data[1].timestamp);
-    REQUIRE(test_data[0].boot_timestamp < test_data[1].boot_timestamp);
+    REQUIRE(test_data[0].timestamp <= test_data[1].timestamp);
+    REQUIRE(test_data[0].boot_timestamp <= test_data[1].boot_timestamp);
+    REQUIRE(test_data[0].boot_timestamp_ms <= test_data[1].boot_timestamp_ms);
+    REQUIRE(test_data[0].timestamp_ms <= test_data[1].timestamp_ms);
     REQUIRE(
         (test_data[1].boot_timestamp - test_data[0].boot_timestamp) >=
         (test_data[1].timestamp - test_data[0].timestamp));

--- a/tests/performance/platform.cpp
+++ b/tests/performance/platform.cpp
@@ -46,7 +46,7 @@ _perf_bpf_ktime_get_boot_ns()
     uint64_t time;
     ebpf_epoch_state_t epoch_state;
     ebpf_epoch_enter(&epoch_state);
-    time = ebpf_query_time_since_boot_precise(true) * EBPF_NS_PER_FILETIME;
+    time = cxplat_query_time_since_boot_precise(true) * EBPF_NS_PER_FILETIME;
     ebpf_epoch_exit(&epoch_state);
 }
 
@@ -56,7 +56,7 @@ _perf_bpf_ktime_get_ns()
     uint64_t time;
     ebpf_epoch_state_t epoch_state;
     ebpf_epoch_enter(&epoch_state);
-    time = ebpf_query_time_since_boot_precise(false) * EBPF_NS_PER_FILETIME;
+    time = cxplat_query_time_since_boot_precise(false) * EBPF_NS_PER_FILETIME;
     ebpf_epoch_exit(&epoch_state);
 }
 

--- a/tests/sample/sample_common_routines.h
+++ b/tests/sample/sample_common_routines.h
@@ -32,6 +32,12 @@ test_utility_helper_functions(void* utility_map)
     // Get the process / thread ID.
     test_data.pid_tgid = bpf_get_current_pid_tgid();
 
+    // Get the timestamp as ms.
+    test_data.boot_timestamp_ms = bpf_ktime_get_boot_ms();
+
+    // Get the timestamp as ms.
+    test_data.timestamp_ms = bpf_ktime_get_ms();
+
     // Write into test utility_map index 0.
     bpf_map_update_elem(utility_map, &keys[0], &test_data, 0);
 
@@ -46,6 +52,12 @@ test_utility_helper_functions(void* utility_map)
 
     // Get the process / thread ID.
     test_data.pid_tgid = bpf_get_current_pid_tgid();
+
+    // Get the timestamp as ms.
+    test_data.boot_timestamp_ms = bpf_ktime_get_boot_ms();
+
+    // Get the timestamp as ms.
+    test_data.timestamp_ms = bpf_ktime_get_ms();
 
     // Write into test utility_map index 1.
     bpf_map_update_elem(utility_map, &keys[1], &test_data, 0);

--- a/tests/sample/sample_test_common.h
+++ b/tests/sample/sample_test_common.h
@@ -15,6 +15,8 @@ typedef struct _ebpf_utility_helpers_data
     uint64_t boot_timestamp;
     uint32_t cpu_id;
     uint64_t pid_tgid;
+    uint64_t boot_timestamp_ms;
+    uint64_t timestamp_ms;
 } ebpf_utility_helpers_data_t;
 
 typedef struct _helper_values


### PR DESCRIPTION
## Description

This pull request introduces new helper functions to obtain system time in milliseconds and replaces existing time query functions with more efficient alternatives. Additionally, it updates relevant test cases to accommodate these changes.

### New Helper Functions:
* [`include/bpf_helper_defs.h`](diffhunk://#diff-88c6095e3a32cc711a4147aab1ef19faec2683079e3b45aeec0f145469326293R476-R497): Added `bpf_ktime_get_boot_ms` and `bpf_ktime_get_ms` functions to return time elapsed since boot in milliseconds, including and excluding time while suspended, respectively.
* [`include/ebpf_structs.h`](diffhunk://#diff-882d18c008c2b18b9fde620e0a51c42158566ce444c249e36093c74483ff4f0fR167-R168): Added `BPF_FUNC_ktime_get_boot_ms` and `BPF_FUNC_ktime_get_ms` to the `ebpf_helper_id_t` enum.

### Codebase Updates:
* [`libs/execution_context/ebpf_core.c`](diffhunk://#diff-865dda5cac7319d91467fb64555d4c45c2b428d6367b44df94f4d13fa56c7ab8R104-R109): Introduced `_ebpf_core_get_time_since_boot_ms` and `_ebpf_core_get_time_ms` functions. Updated `_ebpf_general_helpers` to include these functions. [[1]](diffhunk://#diff-865dda5cac7319d91467fb64555d4c45c2b428d6367b44df94f4d13fa56c7ab8R104-R109) [[2]](diffhunk://#diff-865dda5cac7319d91467fb64555d4c45c2b428d6367b44df94f4d13fa56c7ab8R153-R154)
* [`libs/execution_context/ebpf_core.c`](diffhunk://#diff-865dda5cac7319d91467fb64555d4c45c2b428d6367b44df94f4d13fa56c7ab8L2181-R2215): Replaced `ebpf_query_time_since_boot_precise` and `ebpf_query_time_since_boot_approximate` with `cxplat_query_time_since_boot_precise` and `cxplat_query_time_since_boot_approximate` respectively. [[1]](diffhunk://#diff-865dda5cac7319d91467fb64555d4c45c2b428d6367b44df94f4d13fa56c7ab8L2181-R2215) [[2]](diffhunk://#diff-ae8a7da4edcb9e1f7c73d5704cb00d475c4f847515c8d97c08a178a326ccb27cL1208-R1216) [[3]](diffhunk://#diff-ae8a7da4edcb9e1f7c73d5704cb00d475c4f847515c8d97c08a178a326ccb27cL1260-R1260) [[4]](diffhunk://#diff-6bd70efed6714c9e250113aa729f24539066345c2433fccee1928c62f6657320L2438-R2438) [[5]](diffhunk://#diff-6bd70efed6714c9e250113aa729f24539066345c2433fccee1928c62f6657320L2451-R2451) [[6]](diffhunk://#diff-6bd70efed6714c9e250113aa729f24539066345c2433fccee1928c62f6657320L2463-R2463) [[7]](diffhunk://#diff-6bd70efed6714c9e250113aa729f24539066345c2433fccee1928c62f6657320L2473-R2473)
* [`libs/runtime/ebpf_platform.c`](diffhunk://#diff-9dfbd58f5d316f64d047f68fc95883ef97c3c0b586a6a7e35a6835f3d3f0e4deL223-L250): Removed `ebpf_query_time_since_boot_precise` and `ebpf_query_time_since_boot_approximate` functions.
* [`libs/runtime/ebpf_platform.h`](diffhunk://#diff-2d8c1d862f7672b2b1bd853a82d62da9a2ce750835eaecca82b992a542dd31a7R42): Removed declarations for `ebpf_query_time_since_boot_precise` and `ebpf_query_time_since_boot_approximate`. Added a new macro `EBPF_FILETIME_PER_MS`. [[1]](diffhunk://#diff-2d8c1d862f7672b2b1bd853a82d62da9a2ce750835eaecca82b992a542dd31a7R42) [[2]](diffhunk://#diff-2d8c1d862f7672b2b1bd853a82d62da9a2ce750835eaecca82b992a542dd31a7L649-L671)

### Test Updates:
* [`tests/libs/common/common_tests.cpp`](diffhunk://#diff-2bd9870713f580da19746bfa8a54b38d593e8c22e42861c60c2ebee5273e222fL97-R100): Updated tests to include new timestamp checks for milliseconds.
* [`tests/performance/platform.cpp`](diffhunk://#diff-67966f44da4712c52fdb7af760763eade71ef6fbc469abd7fff165ed2d092f36L49-R49): Replaced `ebpf_query_time_since_boot_precise` with `cxplat_query_time_since_boot_precise`. [[1]](diffhunk://#diff-67966f44da4712c52fdb7af760763eade71ef6fbc469abd7fff165ed2d092f36L49-R49) [[2]](diffhunk://#diff-67966f44da4712c52fdb7af760763eade71ef6fbc469abd7fff165ed2d092f36L59-R59)
* [`tests/sample/sample_common_routines.h`](diffhunk://#diff-985f07af477cd96a0a19dc8337490021295d42e66823d1dbc151a9eae010ebb4R35-R40): Added calls to `bpf_ktime_get_boot_ms` and `bpf_ktime_get_ms` in utility helper functions. [[1]](diffhunk://#diff-985f07af477cd96a0a19dc8337490021295d42e66823d1dbc151a9eae010ebb4R35-R40) [[2]](diffhunk://#diff-985f07af477cd96a0a19dc8337490021295d42e66823d1dbc151a9eae010ebb4R56-R61)
* [`tests/sample/sample_test_common.h`](diffhunk://#diff-d4a0abe28967eb8e3212cc1a4c1ce22544c78506b615adf37a9197f7cf2f8882R18-R19): Added `boot_timestamp_ms` and `timestamp_ms` fields to `ebpf_utility_helpers_data_t` structure.

## Testing

CI/CD

## Documentation

No.

## Installation

No.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced two new helper functions for time retrieval: `bpf_ktime_get_boot_ms` and `bpf_ktime_get_ms`.
	- Added new fields for millisecond timestamps in utility data structures.

- **Bug Fixes**
	- Updated assertions in tests to accommodate equality in timestamp comparisons.

- **Chores**
	- Removed outdated time query functions to streamline the codebase.
	- Enhanced initialization and termination processes of the eBPF platform.

- **Tests**
	- Modified performance tests to utilize the new time query functions.
	- Updated test utility functions to handle new timestamp fields.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->