### PR TITLE
Fix refcount leaks

### DIFF
--- a/libs/execution_context/ebpf_core.c
+++ b/libs/execution_context/ebpf_core.c
@@ -1575,6 +1575,8 @@ _ebpf_core_find_matching_link(
 
     if (match_found) {
         *link = local_link;
+    } else if (local_link != NULL) {
+        EBPF_OBJECT_RELEASE_REFERENCE((ebpf_core_object_t*)local_link);
     }
 
 Exit:

--- a/libs/execution_context/ebpf_program.c
+++ b/libs/execution_context/ebpf_program.c
@@ -1030,6 +1030,11 @@ ebpf_program_associate_maps(ebpf_program_t* program, ebpf_map_t** maps, uint32_t
     }
 
     ebpf_lock_state_t state = ebpf_lock_lock(&program->lock);
+    if (program->maps) {
+        result = EBPF_INVALID_ARGUMENT;
+        ebpf_lock_unlock(&program->lock, state);
+        goto Done;
+    }
     // Now go through again and acquire references.
     program->maps = program_maps;
     program_maps = NULL;

--- a/libs/execution_context/ebpf_program.c
+++ b/libs/execution_context/ebpf_program.c
@@ -1031,6 +1031,8 @@ ebpf_program_associate_maps(ebpf_program_t* program, ebpf_map_t** maps, uint32_t
 
     ebpf_lock_state_t state = ebpf_lock_lock(&program->lock);
     if (program->maps) {
+        EBPF_LOG_MESSAGE(
+            EBPF_TRACELOG_LEVEL_ERROR, EBPF_TRACELOG_KEYWORD_PROGRAM, "Maps already associated with program");
         result = EBPF_INVALID_ARGUMENT;
         ebpf_lock_unlock(&program->lock, state);
         goto Done;


### PR DESCRIPTION
## Description

This pull request includes important changes to the `libs/execution_context` directory, specifically in the `ebpf_core.c` and `ebpf_program.c` files. The changes focus on improving resource management and error handling.

Improvements to resource management:

* [`libs/execution_context/ebpf_core.c`](diffhunk://#diff-865dda5cac7319d91467fb64555d4c45c2b428d6367b44df94f4d13fa56c7ab8R1578-R1579): Added a condition to release the reference to `local_link` if it is not NULL and no match is found in `_ebpf_core_find_matching_link`.

Enhancements to error handling:

* [`libs/execution_context/ebpf_program.c`](diffhunk://#diff-6bd70efed6714c9e250113aa729f24539066345c2433fccee1928c62f6657320R1033-R1037): Added a check to return `EBPF_INVALID_ARGUMENT` and unlock the program's lock if `program->maps` is already set in `ebpf_program_associate_maps`.

## Testing

CI/CD + Fuzzing

## Documentation

No.

## Installation

No.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Enhanced error handling for null pointers in various core functions, preventing potential crashes.
	- Added validation to prevent multiple associations of maps to a single program instance, addressing undefined behavior.

- **Improvements**
	- Improved memory management practices to prevent memory leaks.
	- Updated logging and error reporting for better clarity on invalid arguments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->