### PR TITLE
docs: add crash dump debugging instructions to copilot-instructions.md

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -92,6 +92,69 @@ See [docs/DevelopmentGuide.md](../docs/DevelopmentGuide.md) for full details. Ke
 
 eBPF extensions are kernel drivers providing hooks/helpers via NMR. See [docs/eBpfExtensions.md](../docs/eBpfExtensions.md).
 
+## Crash Dump Debugging
+
+CI workflows (especially `fault_injection_full`) upload crash dumps as artifacts named `Crash-Dumps-*`. To analyze them:
+
+### Prerequisites
+
+1. **Windows Debugging Tools (CDB/WinDbg)** — Install the Debugging Tools feature from the Windows SDK:
+   ```powershell
+   # Download the SDK online installer
+   Invoke-WebRequest -Uri "https://go.microsoft.com/fwlink/?linkid=2272610" -OutFile winsdksetup.exe
+   # Install only the debugging tools (elevated)
+   Start-Process -FilePath .\winsdksetup.exe -ArgumentList "/features","OptionId.WindowsDesktopDebuggers","/quiet","/norestart" -Verb RunAs -Wait
+   ```
+   CDB installs to: `C:\Program Files (x86)\Windows Kits\10\Debuggers\x64\cdb.exe`
+
+2. **mcp-windbg** (MCP server for AI-assisted dump analysis):
+   ```powershell
+   # Install Python 3.12 via NuGet (if not already available)
+   nuget install python -Version 3.12.8 -OutputDirectory C:\Users\$env:USERNAME\tools
+   $pyExe = (Get-ChildItem "C:\Users\$env:USERNAME\tools\python.3.12.8" -Recurse -Filter "python.exe" | Select-Object -First 1).FullName
+   & $pyExe -m ensurepip --upgrade
+   & $pyExe -m pip install mcp-windbg
+   ```
+
+### Downloading Artifacts
+
+```powershell
+# Download crash dumps and build artifacts (PDBs) from a CI run
+gh run download <run_id> -R <owner>/ebpf-for-windows -n "Crash-Dumps-<test>-x64-<config>" -D crash-dumps
+gh run download <run_id> -R <owner>/ebpf-for-windows -n "Build-x64-<config>" -D build
+# Extract inner build zip for PDBs
+Expand-Archive build\build-<config>.zip -DestinationPath build\<config>
+```
+
+### Analyzing Dumps with CDB
+
+```powershell
+$cdbPath = "C:\Program Files (x86)\Windows Kits\10\Debuggers\x64\cdb.exe"
+$symPath = "path\to\build\Debug;SRV*C:\Symbols*https://msdl.microsoft.com/download/symbols"
+
+# Quick triage: exception record + stack trace
+& $cdbPath -z crash-dumps\unit_tests.exe.XXXX.dmp -y $symPath -lines -c ".ecxr;kP;q"
+
+# Full automated analysis
+& $cdbPath -z crash-dumps\unit_tests.exe.XXXX.dmp -y $symPath -c "!analyze -v;q"
+```
+
+### Running mcp-windbg Server
+
+```powershell
+& $pyExe -m mcp_windbg --cdb-path $cdbPath --symbols-path $symPath --transport streamable-http --port 8765
+# MCP endpoint: http://127.0.0.1:8765/mcp
+```
+
+### Common Patterns
+
+- **Fault injection crashes**: Usually assert `_allocations.empty()` in `leak_detector.cpp` — a memory leak detected during teardown. Check the leak detector's `_in_memory_log` for the allocation call stack:
+  ```
+  .ecxr; .frame 0n10; dx this->_in_memory_log
+  ```
+- **Crash dump artifacts**: Named `Crash-Dumps-<test_name>-<platform>-<config>` (e.g., `Crash-Dumps-fault_injection_full-x64-Debug`)
+- **Build artifacts with PDBs**: Named `Build-<platform>-<config>` (e.g., `Build-x64-Debug`), contain an inner zip `build-<config>.zip`
+
 ## Tracing
 
 See "Using tracing" section in [docs/GettingStarted.md](../docs/GettingStarted.md). Quick reference:


### PR DESCRIPTION
## Description

Add a **Crash Dump Debugging** section to \.github/copilot-instructions.md\ so that future Copilot sessions can quickly set up WinDbg/CDB and analyze crash dumps from CI failures without lengthy tool discovery.

The new section covers:
- **Prerequisites**: Installing CDB/WinDbg via the Windows SDK online installer and mcp-windbg via pip
- **Downloading artifacts**: \gh run download\ commands for crash dumps and build PDBs
- **Analyzing dumps with CDB**: Quick triage and full \!analyze -v\ one-liners
- **Running mcp-windbg server**: Command to start the MCP endpoint for AI-assisted analysis
- **Common patterns**: Fault injection leak detection tips, artifact naming conventions, and how to inspect the leak detector's in-memory log

## Testing

Documentation-only change. No tests needed.

## Documentation

This PR **is** the documentation change.

## Installation

No installer impact.